### PR TITLE
axios interceptors 및 baseUrl 설정 및 로그인 api 연결

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -13,7 +13,7 @@
     "@tanstack/react-query": "^4.35.3",
     "@tanstack/react-query-devtools": "^4.35.3",
     "axios": "^1.5.1",
-    "jotai": "^2.4.2",
+    "jotai": "^2.4.3",
     "path": "^0.12.7",
     "quill-image-resize-module-react": "^3.0.0",
     "react": "^18.2.0",

--- a/src/package.json
+++ b/src/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@tanstack/react-query": "^4.35.3",
     "@tanstack/react-query-devtools": "^4.35.3",
+    "axios": "^1.5.1",
     "jotai": "^2.4.2",
     "path": "^0.12.7",
     "quill-image-resize-module-react": "^3.0.0",

--- a/src/src/App.jsx
+++ b/src/src/App.jsx
@@ -7,6 +7,7 @@ import {
   QueryCache,
 } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { Provider as JotaiProvider } from "jotai";
 
 import router from "@/router.jsx";
 import theme from "@/styles/theme.js";
@@ -16,7 +17,8 @@ function App() {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
-        retry: 0,
+        retry: 1,
+        staleTime: 1 * 60 * 1000,
       },
     },
     queryCache: new QueryCache({
@@ -27,15 +29,17 @@ function App() {
   });
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <ReactQueryDevtools initialIsOpen={false} />
-      <HelmetProvider>
-        <StyledThemeProvider theme={theme}>
-          <GlobalStyle />
-          <RouterProvider router={router} />
-        </StyledThemeProvider>
-      </HelmetProvider>
-    </QueryClientProvider>
+    <JotaiProvider>
+      <QueryClientProvider client={queryClient}>
+        <ReactQueryDevtools initialIsOpen={false} />
+        <HelmetProvider>
+          <StyledThemeProvider theme={theme}>
+            <GlobalStyle />
+            <RouterProvider router={router} />
+          </StyledThemeProvider>
+        </HelmetProvider>
+      </QueryClientProvider>
+    </JotaiProvider>
   );
 }
 

--- a/src/src/api/authAPI.js
+++ b/src/src/api/authAPI.js
@@ -1,6 +1,17 @@
+import instance from "@/api/instance.js";
+import API from "@/constants/API.js";
+
+const signIn = async ({ email, password }) => {
+  await instance({
+    url: API.AUTH.LOGIN,
+    method: "POST",
+    data: { email: email, password: password },
+  });
+};
+
 const refreshToken = ({ baseUrl, refreshToken }) => {
   // api 통신
   return "refreshedAccessToken";
 };
 
-export default { refreshToken };
+export default { signIn, refreshToken };

--- a/src/src/api/authAPI.js
+++ b/src/src/api/authAPI.js
@@ -1,8 +1,8 @@
 import instance from "@/api/instance.js";
 import API from "@/constants/API.js";
 
-const signIn = async ({ email, password }) => {
-  await instance({
+const postLogin = async ({ email, password }) => {
+  return await instance({
     url: API.AUTH.LOGIN,
     method: "POST",
     data: { email: email, password: password },
@@ -14,4 +14,4 @@ const refreshToken = ({ baseUrl, refreshToken }) => {
   return "refreshedAccessToken";
 };
 
-export default { signIn, refreshToken };
+export default { postLogin, refreshToken };

--- a/src/src/api/authAPI.js
+++ b/src/src/api/authAPI.js
@@ -1,0 +1,6 @@
+const refreshToken = ({ baseUrl, refreshToken }) => {
+  // api 통신
+  return "refreshedAccessToken";
+};
+
+export default { refreshToken };

--- a/src/src/api/instance.js
+++ b/src/src/api/instance.js
@@ -1,5 +1,6 @@
 import axios from "axios";
 import TOKEN from "@/constants/TOKEN.js";
+import authAPI from "@/api/authAPI.js";
 
 const baseUrl = import.meta.env.VITE_USE_MOCK_API
   ? `${import.meta.env.BASE_URL}/api`
@@ -18,11 +19,40 @@ instance.interceptors.request.use(
 
     if (!accessToken) return config;
 
-    config.headers.Authorization = accessToken;
+    config.headers.Authorization = `Bearer accessToken`;
     return config;
   },
   function (err) {
     return Promise.reject(err);
+  },
+);
+
+instance.interceptors.response.use(
+  function (response) {
+    return response;
+  },
+  async function (err) {
+    if (!err.response || !err.response.status) {
+      return Promise.reject(err);
+    }
+
+    switch (err.response.status) {
+      case 401: {
+        localStorage.removeItem(TOKEN.ACCESS);
+        const originalRequest = err.config;
+        const refreshToken = localStorage.getItem(TOKEN.REFRESH);
+
+        if (!refreshToken) return Promise.reject(err);
+
+        const newAccessToken = authAPI.refreshToken({ baseUrl, refreshToken });
+        localStorage.setItem(TOKEN.ACCESS, newAccessToken);
+
+        originalRequest.headers.authorization = `Bearer ${newAccessToken}`;
+        return axios(originalRequest);
+      }
+      default:
+        return Promise.reject(err);
+    }
   },
 );
 

--- a/src/src/api/instance.js
+++ b/src/src/api/instance.js
@@ -1,0 +1,14 @@
+import axios from "axios";
+
+const baseUrl = import.meta.env.VITE_USE_MOCK_API
+  ? `${import.meta.env.BASE_URL}/api`
+  : import.meta.env.VITE_FUNDERING_API;
+
+const instance = axios.create({
+  baseURL: baseUrl,
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
+export default instance;

--- a/src/src/api/instance.js
+++ b/src/src/api/instance.js
@@ -38,9 +38,10 @@ instance.interceptors.response.use(
 
     switch (err.response.status) {
       case 401: {
-        localStorage.removeItem(TOKEN.ACCESS);
         const originalRequest = err.config;
         const refreshToken = localStorage.getItem(TOKEN.REFRESH);
+        localStorage.removeItem(TOKEN.ACCESS);
+        localStorage.removeItem(TOKEN.REFRESH);
 
         if (!refreshToken) return Promise.reject(err);
 

--- a/src/src/api/instance.js
+++ b/src/src/api/instance.js
@@ -1,4 +1,5 @@
 import axios from "axios";
+import TOKEN from "@/constants/TOKEN.js";
 
 const baseUrl = import.meta.env.VITE_USE_MOCK_API
   ? `${import.meta.env.BASE_URL}/api`
@@ -10,5 +11,19 @@ const instance = axios.create({
     "Content-Type": "application/json",
   },
 });
+
+instance.interceptors.request.use(
+  function (config) {
+    const accessToken = localStorage.getItem(TOKEN.ACCESS);
+
+    if (!accessToken) return config;
+
+    config.headers.Authorization = accessToken;
+    return config;
+  },
+  function (err) {
+    return Promise.reject(err);
+  },
+);
 
 export default instance;

--- a/src/src/api/instance.js
+++ b/src/src/api/instance.js
@@ -3,7 +3,7 @@ import TOKEN from "@/constants/TOKEN.js";
 import authAPI from "@/api/authAPI.js";
 
 const baseUrl = import.meta.env.VITE_USE_MOCK_API
-  ? `${import.meta.env.BASE_URL}/api`
+  ? "http://localhost:5173/api"
   : import.meta.env.VITE_FUNDERING_API;
 
 const instance = axios.create({

--- a/src/src/components/common/form/Form.jsx
+++ b/src/src/components/common/form/Form.jsx
@@ -30,7 +30,7 @@ function Form({
         onSubmit={handleSubmit(onSubmit, onError)}
         style={{ width: "100%", maxWidth: "22rem" }}
       >
-        {inputInformations.map((input) => (
+        {inputInformations.map(input => (
           <LabeledInput
             key={input.id}
             id={input.id}
@@ -58,13 +58,7 @@ Form.propTypes = {
       id: PropTypes.string.isRequired,
       type: PropTypes.string.isRequired,
       placeholder: PropTypes.string.isRequired,
-      validation: PropTypes.shape({
-        required: PropTypes.string,
-        pattern: PropTypes.shape({
-          value: PropTypes.any,
-          message: PropTypes.string,
-        }),
-      }),
+      validation: PropTypes.object,
       requireMsg: PropTypes.string,
     }),
   ),
@@ -73,12 +67,6 @@ Form.propTypes = {
 };
 
 Form.defaultProps = {
-  onSubmit: (data) => {
-    console.log(data);
-  },
-  onError: (err) => {
-    console.log(err);
-  },
   defaultValues: { userId: "" },
   inputInformations: [
     {

--- a/src/src/components/common/nav-bar/moblie/MobileSideBar.jsx
+++ b/src/src/components/common/nav-bar/moblie/MobileSideBar.jsx
@@ -10,6 +10,8 @@ import routes from "@/constants/routes.js";
 import useBodyStyleFixed from "@/hooks/useBodyStyleFixed.js";
 import useOutsideClick from "@/hooks/useOutsideClick.js";
 import PAGE_LIST from "@/constants/PAGE_LIST.js";
+import { useAtomValue } from "jotai";
+import accessTokenAtom from "@/storage/accessToken.atom.js";
 
 const Keyframes = {
   appear: keyframes`
@@ -84,7 +86,8 @@ function MobileSideBar({ setIsSideBarOpen }) {
   useOutsideClick(sideBarRef, () => setIsSideBarOpen(false));
   useBodyStyleFixed();
 
-  const isLoggedIn = true;
+  const accessToken = useAtomValue(accessTokenAtom);
+  const isLoggedIn = accessToken && accessToken !== "";
 
   const userInfo = {
     profileUrl:
@@ -119,7 +122,7 @@ function MobileSideBar({ setIsSideBarOpen }) {
 
           {isLoggedIn && (
             <ul>
-              {PAGE_LIST.USER_MENU.map((page) => (
+              {PAGE_LIST.USER_MENU.map(page => (
                 <Styled.Menu
                   key={page.title}
                   onClick={() => {

--- a/src/src/components/common/nav-bar/pc/PCUserBtn.jsx
+++ b/src/src/components/common/nav-bar/pc/PCUserBtn.jsx
@@ -6,6 +6,8 @@ import TestAccountIcon from "@/assets/icon/TestAccountIcon.jsx";
 import routes from "@/constants/routes.js";
 import useOutsideClick from "@/hooks/useOutsideClick.js";
 import PAGE_LIST from "@/constants/PAGE_LIST.js";
+import { useAtomValue } from "jotai";
+import accessTokenAtom from "@/storage/accessToken.atom.js";
 
 const Styled = {
   UserBtn: styled.button`
@@ -59,7 +61,9 @@ function PCUserBtn() {
   const [isMenuModalOpen, setIsMenuModalOpen] = useState(false);
   useOutsideClick(userBtnRef, () => setIsMenuModalOpen(false));
 
-  const isLoggedIn = true;
+  const accessToken = useAtomValue(accessTokenAtom);
+  const isLoggedIn = accessToken && accessToken !== "";
+
   const userInfo = {
     profileUrl:
       "https://velog.velcdn.com/images/j8won/profile/55917697-2140-40be-ad07-d2d02137f38e/image.jpeg",
@@ -85,7 +89,7 @@ function PCUserBtn() {
 
       {isMenuModalOpen && (
         <Styled.Modal>
-          {PAGE_LIST.USER_MENU.map((page) => (
+          {PAGE_LIST.USER_MENU.map(page => (
             <Styled.Menu
               key={page.title}
               onClick={() => {

--- a/src/src/constants/API.js
+++ b/src/src/constants/API.js
@@ -1,0 +1,12 @@
+const AUTH = {
+  LOGIN: "/login",
+  SIGN_UP: "/signup",
+};
+
+const FUND = {
+  GET_LIST: "/posts",
+};
+
+Object.freeze(AUTH);
+Object.freeze(FUND);
+export default { AUTH, FUNDS: FUND };

--- a/src/src/constants/API.js
+++ b/src/src/constants/API.js
@@ -7,6 +7,11 @@ const FUND = {
   GET_LIST: "/posts",
 };
 
+const QUERY_KEY = {
+  POST_LOGIN: "postLogIn",
+};
+
 Object.freeze(AUTH);
 Object.freeze(FUND);
-export default { AUTH, FUNDS: FUND };
+Object.freeze(QUERY_KEY);
+export default { AUTH, FUND, QUERY_KEY };

--- a/src/src/constants/TOKEN.js
+++ b/src/src/constants/TOKEN.js
@@ -1,0 +1,7 @@
+const TOKEN = {
+  ACCESS: "accessToken",
+  REFRESH: "refreshToken",
+};
+
+Object.freeze(TOKEN);
+export default { TOKEN };

--- a/src/src/hooks/api/useLogInMutation.js
+++ b/src/src/hooks/api/useLogInMutation.js
@@ -1,0 +1,37 @@
+import { useMutation } from "@tanstack/react-query";
+import { useSetAtom } from "jotai";
+import { useNavigate } from "react-router-dom";
+import toast from "react-hot-toast";
+
+import authAPI from "@/api/authAPI.js";
+import API from "@/constants/API.js";
+import routes from "@/constants/routes.js";
+import accessTokenAtom from "@/storage/accessToken.atom.js";
+import refreshTokenAtom from "@/storage/refreshToken.atom.js";
+
+function useLogInMutation() {
+  const setAccessToken = useSetAtom(accessTokenAtom);
+  const setRefreshToken = useSetAtom(refreshTokenAtom);
+  const navigate = useNavigate();
+
+  return useMutation(
+    [API.QUERY_KEY.POST_LOGIN],
+    async ({ email, password }) => {
+      return await authAPI.postLogin({ email, password });
+    },
+    {
+      onSuccess: ({ data }) => {
+        const { accessToken, refreshToken } = data;
+        setAccessToken(accessToken);
+        setRefreshToken(refreshToken);
+        toast.success("로그인에 성공했습니다");
+        navigate(routes.home);
+      },
+      onError: () => {
+        toast.error("로그인에 실패했습니다");
+      },
+    },
+  );
+}
+
+export default useLogInMutation;

--- a/src/src/hooks/api/useLogInMutation.js
+++ b/src/src/hooks/api/useLogInMutation.js
@@ -25,7 +25,7 @@ function useLogInMutation() {
         setAccessToken(accessToken);
         setRefreshToken(refreshToken);
         toast.success("로그인에 성공했습니다");
-        navigate(routes.home);
+        navigate(routes.home, { replace: true });
       },
       onError: () => {
         toast.error("로그인에 실패했습니다");

--- a/src/src/mocks/browser.js
+++ b/src/src/mocks/browser.js
@@ -1,4 +1,4 @@
 import { setupWorker } from "msw";
-import { handlers } from "@/mocks/handlers.js";
+import { handlers } from "@/mocks/handler/index.js";
 
 export const worker = setupWorker(...handlers);

--- a/src/src/mocks/handler/authHandlers.js
+++ b/src/src/mocks/handler/authHandlers.js
@@ -1,0 +1,15 @@
+import { rest } from "msw";
+import API from "@/constants/API.js";
+
+export const authHandlers = [
+  rest.post("/api" + API.AUTH.LOGIN, (req, res, ctx) => {
+    const { email, password } = req.json();
+
+    if (!email || !password) return res(ctx.status(400));
+
+    return res(
+      ctx.status(200),
+      ctx.json({ accessToken: "accessToken", refreshToken: "refreshToken" }),
+    );
+  }),
+];

--- a/src/src/mocks/handler/authHandlers.js
+++ b/src/src/mocks/handler/authHandlers.js
@@ -3,9 +3,13 @@ import API from "@/constants/API.js";
 
 export const authHandlers = [
   rest.post("/api" + API.AUTH.LOGIN, (req, res, ctx) => {
-    const { email, password } = req.json();
+    const { email, password } = req.body;
 
-    if (!email || !password) return res(ctx.status(400));
+    if (!email || !password)
+      return res(
+        ctx.status(400),
+        ctx.json({ email: email, password: password }),
+      );
 
     return res(
       ctx.status(200),

--- a/src/src/mocks/handler/fundHandlers.js
+++ b/src/src/mocks/handler/fundHandlers.js
@@ -1,0 +1,40 @@
+import API from "@/constants/API.js";
+import { rest } from "msw";
+
+export const fundHandlers = [
+  rest.get("/api" + API.FUNDS.GET_LIST, (req, res, ctx) => {
+    const keyword = req.url.searchParams.get("keyword");
+    const pageIndex = req.url.searchParams.get("pageIndex");
+    const accessToken = req.headers.get("accessToken");
+
+    const sonnyFundInfo = {
+      fundId: 1,
+      fundTitle:
+        "손흥민 주장된 기념 지하철 광고 🎉🎉 축구중독자가 책임지고 펀딩합니다 ❤️‍🔥",
+      thumbnailUrl:
+        "https://ichef.bbci.co.uk/news/640/cpsprodpb/4118/production/_119546661_gettyimages-1294130887.jpg",
+      targetDate: "2023-12-17",
+      targetMoney: "3000000",
+      currentMoney: "2340000",
+      celebrityId: "sonny",
+      celebrityName: "손흥민",
+      celebrityProfileUrl:
+        "https://pds.joongang.co.kr/news/component/htmlphoto_mmdata/202308/13/3756de8c-1ea6-4988-b063-25f26d9b76d5.jpg",
+      organizerId: "soccer123",
+      organizerName: "축구도사",
+      isInUserWishList: !!accessToken,
+    };
+
+    if (!pageIndex) return res(ctx.status(400, "pageIndex 없음"));
+
+    return res(
+      ctx.status(200),
+      ctx.json({
+        isLastPage: false,
+        currentPage: pageIndex + 1,
+        fundList: [Array(10).fill(sonnyFundInfo)],
+        keyword: keyword,
+      }),
+    );
+  }),
+];

--- a/src/src/mocks/handler/fundHandlers.js
+++ b/src/src/mocks/handler/fundHandlers.js
@@ -2,7 +2,7 @@ import API from "@/constants/API.js";
 import { rest } from "msw";
 
 export const fundHandlers = [
-  rest.get("/api" + API.FUNDS.GET_LIST, (req, res, ctx) => {
+  rest.get("/api" + API.FUND.GET_LIST, (req, res, ctx) => {
     const keyword = req.url.searchParams.get("keyword");
     const pageIndex = req.url.searchParams.get("pageIndex");
     const accessToken = req.headers.get("accessToken");

--- a/src/src/mocks/handler/index.js
+++ b/src/src/mocks/handler/index.js
@@ -1,0 +1,4 @@
+import { authHandlers } from "@/mocks/handler/authHandlers.js";
+import { fundHandlers } from "@/mocks/handler/fundHandlers.js";
+
+export const handlers = [...authHandlers, ...fundHandlers];

--- a/src/src/mocks/handlers.js
+++ b/src/src/mocks/handlers.js
@@ -1,8 +1,0 @@
-import { rest } from "msw";
-
-export const handlers = [
-  rest.post("/api/login", (ctx, res, req) => {
-    return res(ctx.status(200));
-  }),
-  rest.get("/user", null),
-];

--- a/src/src/pages/CreateFund.page.jsx
+++ b/src/src/pages/CreateFund.page.jsx
@@ -109,7 +109,7 @@ function CreateFundPage() {
         <Styled.TitleInput
           placeholder="펀딩 제목을 입력하세요"
           value={title}
-          onChange={(e) => setTitle(e.target.value)}
+          onChange={e => setTitle(e.target.value)}
         />
       </Styled.InputContainer>
 

--- a/src/src/pages/Login.page.jsx
+++ b/src/src/pages/Login.page.jsx
@@ -9,6 +9,7 @@ import FORM_INFO from "@/constants/FORM_INFO.js";
 import FORM_DEFAULT from "@/constants/FORM_DEFAULT.js";
 import { FormTemplate, Title } from "@/styles/CommonStyle.js";
 import PageTitle from "@/components/common/PageTitle.jsx";
+import useLogInMutation from "@/hooks/api/useLogInMutation.js";
 
 const Styled = {
   LoginTitle: styled(Title)`
@@ -33,13 +34,17 @@ const Styled = {
 function LoginPage() {
   const navigate = useNavigate();
 
+  const { mutate: loginMutate } = useLogInMutation();
+
   return (
     <>
       <PageTitle title="로그인" />
       <FormTemplate>
         <Styled.LoginTitle>로그인</Styled.LoginTitle>
         <Form
-          onSubmit={data => console.log(data)}
+          onSubmit={({ email, password }) => {
+            loginMutate({ email, password });
+          }}
           onError={err => console.log(err)}
           inputInformations={FORM_INFO.SIGN_IN}
           defaultValues={FORM_DEFAULT.SIGN_IN}

--- a/src/src/pages/Login.page.jsx
+++ b/src/src/pages/Login.page.jsx
@@ -39,8 +39,8 @@ function LoginPage() {
       <FormTemplate>
         <Styled.LoginTitle>로그인</Styled.LoginTitle>
         <Form
-          onSubmit={(data) => console.log(data)}
-          onError={(err) => console.log(err)}
+          onSubmit={data => console.log(data)}
+          onError={err => console.log(err)}
           inputInformations={FORM_INFO.SIGN_IN}
           defaultValues={FORM_DEFAULT.SIGN_IN}
         >

--- a/src/src/pages/MyAccount.page.jsx
+++ b/src/src/pages/MyAccount.page.jsx
@@ -8,6 +8,11 @@ import FORM_DEFAULT from "@/constants/FORM_DEFAULT.js";
 import FORM_INFO from "@/constants/FORM_INFO.js";
 import BUTTON_TYPE from "@/constants/BUTTON_TYPE.js";
 import { FormTemplate } from "@/styles/CommonStyle.js";
+import { useSetAtom } from "jotai";
+import accessTokenAtom from "@/storage/accessToken.atom.js";
+import refreshTokenAtom from "@/storage/refreshToken.atom.js";
+import { useNavigate } from "react-router-dom";
+import routes from "@/constants/routes.js";
 
 const Styled = {
   Title: styled.h2`
@@ -18,6 +23,9 @@ const Styled = {
 
 function MyAccountPage() {
   const [profileImageFile, setProfileImageFile] = useState(null);
+  const navigate = useNavigate();
+  const setAccessToken = useSetAtom(accessTokenAtom);
+  const setRefreshToken = useSetAtom(refreshTokenAtom);
 
   const loadedProfileUrl =
     "https://velog.velcdn.com/images/j8won/profile/55917697-2140-40be-ad07-d2d02137f38e/image.jpeg";
@@ -48,8 +56,8 @@ function MyAccountPage() {
         setImageFile={setProfileImageFile}
       />
       <Form
-        onSubmit={(data) => console.log(data)}
-        onError={(err) => console.log(err)}
+        onSubmit={data => console.log(data)}
+        onError={err => console.log(err)}
         inputInformations={FORM_INFO.MY_ACCOUNT}
         defaultValues={loadedDefaultValues}
       >
@@ -69,7 +77,9 @@ function MyAccountPage() {
       <Button
         styleType={BUTTON_TYPE.SECONDARY}
         onClick={() => {
-          // accessToken, refreshToken 삭제
+          setAccessToken("");
+          setRefreshToken("");
+          navigate(routes.home);
         }}
         style={{
           width: "100%",

--- a/src/src/storage/accessToken.atom.js
+++ b/src/src/storage/accessToken.atom.js
@@ -1,0 +1,5 @@
+import { atomWithStorage } from "jotai/utils";
+
+const accessTokenAtom = atomWithStorage("accessToken", "");
+
+export default accessTokenAtom;

--- a/src/src/storage/refreshToken.atom.js
+++ b/src/src/storage/refreshToken.atom.js
@@ -1,0 +1,5 @@
+import { atomWithStorage } from "jotai/utils";
+
+const refreshTokenAtom = atomWithStorage("refreshToken", "");
+
+export default refreshTokenAtom;

--- a/src/yarn.lock
+++ b/src/yarn.lock
@@ -3101,10 +3101,10 @@ iterator.prototype@^1.1.2:
     reflect.getprototypeof "^1.0.4"
     set-function-name "^2.0.1"
 
-jotai@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/jotai/-/jotai-2.4.2.tgz#85610d82d247a7b19de7cce82e8d3ddf007f8d4d"
-  integrity sha512-90jXVOd9h6gi5JXk558M+wnJfaaVN2WegcNOCfiFbWboNaDl6DkRgiY/K1oeqTfYJmq8yM7XPsL99LAvcOPqhw==
+jotai@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/jotai/-/jotai-2.4.3.tgz#a8eff8ca6de968d6a04616329dd1335ce52e70f3"
+  integrity sha512-CSAHX9LqWG5WCrU8OgBoZbBJ+Bo9rQU0mPusEF4e0CZ/SNFgurG26vb3UpgvCSJZgYVcUQNiUBM5q86PA8rstQ==
 
 js-levenshtein@^1.1.6:
   version "1.1.6"

--- a/src/yarn.lock
+++ b/src/yarn.lock
@@ -1654,10 +1654,24 @@ asynciterator.prototype@^1.0.0:
   dependencies:
     has-symbols "^1.0.3"
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 available-typed-arrays@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
+
+axios@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.5.1.tgz#11fbaa11fc35f431193a9564109c88c1f27b585f"
+  integrity sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 babel-plugin-polyfill-corejs2@^0.4.5:
   version "0.4.5"
@@ -1896,6 +1910,13 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
@@ -2029,6 +2050,11 @@ define-properties@^1.1.3, define-properties@^1.1.4, define-properties@^1.2.0, de
     define-data-property "^1.0.1"
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -2497,12 +2523,26 @@ flatted@^3.2.7:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
 
+follow-redirects@^1.15.0:
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
+  integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
   integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
   dependencies:
     is-callable "^1.1.3"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 fs-readdir-recursive@^1.1.0:
   version "1.1.0"
@@ -3283,6 +3323,18 @@ micromatch@^4.0.4:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
@@ -3645,6 +3697,11 @@ prop-types@^15.7.2, prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 punycode@^2.1.0:
   version "2.3.0"


### PR DESCRIPTION
## 주요 사항
- axios interceptors 설정을 활용해 refreshToken을 활용한 자동으로 accessToken 재발급 요청 로직 추가
- msw 수정
- useLoginMutate
  - 로그인 성공 시 jotai의 atomWithStorage를 활용해 localStorage에 accessToken, refreshToken 저장
  - 성공과 실패에 따라 toast 메시지로 알려줌
  - 성공 시 메인 페이지로 이동
- 나비게이션 바: jotai를 활용한 로그인 여부 판단
- 로그아웃시 jotai를 활용해 토큰 관련 삭제

- 추후 api 변경에 따라 변경될 수 있음
- 추후 로그인 여부에 따른 라우터 접근 제한 구현해야 함

## 스크린샷
<img width="1435" alt="image" src="https://github.com/Step3-kakao-tech-campus/Team13_FE/assets/75734220/6bce188c-1804-4e44-b083-28529c314444">
<img width="1435" alt="image" src="https://github.com/Step3-kakao-tech-campus/Team13_FE/assets/75734220/2df97e4d-e58b-4688-b567-cbffd8c58080">



### 관련 이슈
close #69 
