### PR TITLE
셀럽상세페이지

### DIFF
--- a/src/src/assets/icon/FirstRibbonIcon.jsx
+++ b/src/src/assets/icon/FirstRibbonIcon.jsx
@@ -1,9 +1,11 @@
-function FirstRibbonIcon() {
+import { PropTypes } from "prop-types";
+
+function FirstRibbonIcon({ size = 48 }) {
   return (
     <>
       <img
-        width="48"
-        height="48"
+        width={size}
+        height={size}
         src="https://img.icons8.com/color/48/first-place-ribbon.png"
         alt="first-place-ribbon"
       />
@@ -16,5 +18,9 @@ function FirstRibbonIcon() {
     </>
   );
 }
+
+FirstRibbonIcon.propTypes = {
+  size: PropTypes.number,
+};
 
 export default FirstRibbonIcon;

--- a/src/src/assets/icon/InProgressIcon.jsx
+++ b/src/src/assets/icon/InProgressIcon.jsx
@@ -1,9 +1,11 @@
-function InProgressIcon() {
+import { PropTypes } from "prop-types";
+
+function InProgressIcon({ size = 16 }) {
   return (
     <>
       <img
-        width="16"
-        height="16"
+        width={size}
+        height={size}
         src="https://img.icons8.com/material-rounded/192/aaaaaa/in-progress.png"
         alt="in-progress"
       />
@@ -14,5 +16,9 @@ function InProgressIcon() {
     </>
   );
 }
+
+InProgressIcon.propTypes = {
+  size: PropTypes.number,
+};
 
 export default InProgressIcon;

--- a/src/src/assets/icon/MoneyIcon.jsx
+++ b/src/src/assets/icon/MoneyIcon.jsx
@@ -1,9 +1,11 @@
-function MoneyIcon() {
+import { PropTypes } from "prop-types";
+
+function MoneyIcon({ size = 16 }) {
   return (
     <>
       <img
-        width="16"
-        height="16"
+        width={size}
+        height={size}
         src="https://img.icons8.com/material-rounded/192/aaaaaa/money-bag.png"
         alt="money-bag"
       />
@@ -14,5 +16,9 @@ function MoneyIcon() {
     </>
   );
 }
+
+MoneyIcon.propTypes = {
+  size: PropTypes.number,
+};
 
 export default MoneyIcon;

--- a/src/src/assets/icon/SecondRibbonIcon.jsx
+++ b/src/src/assets/icon/SecondRibbonIcon.jsx
@@ -1,9 +1,11 @@
-function SecondRibbonIcon() {
+import { PropTypes } from "prop-types";
+
+function SecondRibbonIcon({ size = 48 }) {
   return (
     <>
       <img
-        width="48"
-        height="48"
+        width={size}
+        height={size}
         src="https://img.icons8.com/color/48/second-place-ribbon.png"
         alt="second-place-ribbon"
       />
@@ -16,5 +18,9 @@ function SecondRibbonIcon() {
     </>
   );
 }
+
+SecondRibbonIcon.propTypes = {
+  size: PropTypes.number,
+};
 
 export default SecondRibbonIcon;

--- a/src/src/assets/icon/ThirdRibbonIcon.jsx
+++ b/src/src/assets/icon/ThirdRibbonIcon.jsx
@@ -1,9 +1,11 @@
-function ThirdRibbonIcon() {
+import { PropTypes } from "prop-types";
+
+function ThirdRibbonIcon({ size = 48 }) {
   return (
     <>
       <img
-        width="48"
-        height="48"
+        width={size}
+        height={size}
         src="https://img.icons8.com/color/48/third-place-ribbon.png"
         alt="third-place-ribbon"
       />
@@ -17,4 +19,7 @@ function ThirdRibbonIcon() {
   );
 }
 
+ThirdRibbonIcon.propTypes = {
+  size: PropTypes.number,
+};
 export default ThirdRibbonIcon;

--- a/src/src/assets/icon/UserIcon.jsx
+++ b/src/src/assets/icon/UserIcon.jsx
@@ -1,9 +1,11 @@
-function UserIcon() {
+import { PropTypes } from "prop-types";
+
+function UserIcon({ size = 16 }) {
   return (
     <>
       <img
-        width="16"
-        height="16"
+        width={size}
+        height={size}
         src="https://img.icons8.com/material-rounded/192/aaaaaa/user.png"
         alt="user"
       />
@@ -14,5 +16,9 @@ function UserIcon() {
     </>
   );
 }
+
+UserIcon.propTypes = {
+  size: PropTypes.number,
+};
 
 export default UserIcon;

--- a/src/src/components/celebrity-detail/CelebProfile.jsx
+++ b/src/src/components/celebrity-detail/CelebProfile.jsx
@@ -26,7 +26,7 @@ const Styled = {
   `,
 
   Img: styled.img`
-    width: 9rem;
+    width: 9.5rem;
     border-radius: 0.25rem;
   `,
 };

--- a/src/src/components/celebrity-detail/CelebProfile.jsx
+++ b/src/src/components/celebrity-detail/CelebProfile.jsx
@@ -7,7 +7,7 @@ const Styled = {
     flex-direction: column;
   `,
 
-  NameAndAffiliation: styled.div`
+  NameAndGroup: styled.div`
     font-size: 1.5rem;
     font-weight: 600;
 
@@ -34,7 +34,7 @@ const Styled = {
 /**
  * 셀럽 프로필 컴포넌트 - 셀럽신청에 명시했던 정보와 프로필이미지를 보여줌
  * @param {string} props.celebName - 셀럽의 이름
- * @param {string} props.affiliation - 셀럽의 소속
+ * @param {string} props.celebGroup - 셀럽의 소속
  * @param {string} props.celebCategory - 셀럽의 분류
  * @param {string} props.celebGender - 셀럽의 성별
  * @param {string} props.profileUrl - 셀럽의 프로필 사진 URL
@@ -42,17 +42,17 @@ const Styled = {
 
 function CelebProfile({
   celebName,
-  affiliation,
+  celebGroup,
   celebCategory,
   celebGender,
   profileUrl,
 }) {
   return (
     <Styled.ProfileContainer>
-      <Styled.NameAndAffiliation>
+      <Styled.NameAndGroup>
         {celebName}
-        {affiliation && <span>{affiliation}</span>}
-      </Styled.NameAndAffiliation>
+        {celebGroup && <span>{celebGroup}</span>}
+      </Styled.NameAndGroup>
 
       <Styled.CategoryAndGender>{`${celebCategory} • ${celebGender}`}</Styled.CategoryAndGender>
 
@@ -65,7 +65,7 @@ export default CelebProfile;
 
 CelebProfile.propTypes = {
   celebName: PropTypes.string.isRequired,
-  affiliation: PropTypes.string,
+  celebGroup: PropTypes.string,
   celebCategory: PropTypes.string.isRequired,
   celebGender: PropTypes.string.isRequired,
   profileUrl: PropTypes.string,

--- a/src/src/components/celebrity-detail/CelebProfile.jsx
+++ b/src/src/components/celebrity-detail/CelebProfile.jsx
@@ -63,7 +63,7 @@ function CelebProfile({
 
 export default CelebProfile;
 
-CelebProfile.PropTypes = {
+CelebProfile.propTypes = {
   celebName: PropTypes.string.isRequired,
   affiliation: PropTypes.string,
   celebCategory: PropTypes.string.isRequired,

--- a/src/src/components/celebrity-detail/CelebProfile.jsx
+++ b/src/src/components/celebrity-detail/CelebProfile.jsx
@@ -1,0 +1,22 @@
+function CelebProfile({
+  celebName,
+  affiliation,
+  celebCategory,
+  celebGender,
+  profileUrl,
+}) {
+  return (
+    <div>
+      <div className="nameAndAffiliation">
+        <span>{celebName}</span>
+        {affiliation && <span>{affiliation}</span>}
+      </div>
+      <div className="categoryAndGender">
+        <span>{`${celebCategory} • ${celebGender}`}</span>
+      </div>
+      <img src={profileUrl} alt="셀럽프로필사진" style={{ width: "9rem" }} />
+    </div>
+  );
+}
+
+export default CelebProfile;

--- a/src/src/components/celebrity-detail/CelebProfile.jsx
+++ b/src/src/components/celebrity-detail/CelebProfile.jsx
@@ -1,3 +1,36 @@
+import styled from "styled-components";
+import { PropTypes } from "prop-types";
+
+const Styled = {
+  ProfileContainer: styled.div`
+    display: flex;
+    flex-direction: column;
+  `,
+
+  NameAndAffiliation: styled.div`
+    font-size: 1.5rem;
+    font-weight: 600;
+
+    & span {
+      font-size: 1rem;
+      font-weight: 400;
+      margin-left: 0.5rem;
+      color: ${({ theme }) => theme.color.addition};
+    }
+  `,
+
+  CategoryAndGender: styled.div`
+    margin: 0.5rem 0;
+    font-size: 1rem;
+    color: ${({ theme }) => theme.color.addition};
+  `,
+
+  Img: styled.img`
+    width: 9rem;
+    border-radius: 0.25rem;
+  `,
+};
+
 function CelebProfile({
   celebName,
   affiliation,
@@ -6,17 +39,25 @@ function CelebProfile({
   profileUrl,
 }) {
   return (
-    <div>
-      <div className="nameAndAffiliation">
-        <span>{celebName}</span>
+    <Styled.ProfileContainer>
+      <Styled.NameAndAffiliation>
+        {celebName}
         {affiliation && <span>{affiliation}</span>}
-      </div>
-      <div className="categoryAndGender">
-        <span>{`${celebCategory} • ${celebGender}`}</span>
-      </div>
-      <img src={profileUrl} alt="셀럽프로필사진" style={{ width: "9rem" }} />
-    </div>
+      </Styled.NameAndAffiliation>
+
+      <Styled.CategoryAndGender>{`${celebCategory} • ${celebGender}`}</Styled.CategoryAndGender>
+
+      <Styled.Img src={profileUrl} alt="셀럽프로필사진" />
+    </Styled.ProfileContainer>
   );
 }
 
 export default CelebProfile;
+
+CelebProfile.PropTypes = {
+  celebName: PropTypes.string.isRequired,
+  affiliation: PropTypes.string,
+  celebCategory: PropTypes.string.isRequired,
+  celebGender: PropTypes.string.isRequired,
+  profileUrl: PropTypes.string,
+};

--- a/src/src/components/celebrity-detail/CelebProfile.jsx
+++ b/src/src/components/celebrity-detail/CelebProfile.jsx
@@ -31,6 +31,15 @@ const Styled = {
   `,
 };
 
+/**
+ * 셀럽 프로필 컴포넌트 - 셀럽신청에 명시했던 정보와 프로필이미지를 보여줌
+ * @param {string} props.celebName - 셀럽의 이름
+ * @param {string} props.affiliation - 셀럽의 소속
+ * @param {string} props.celebCategory - 셀럽의 분류
+ * @param {string} props.celebGender - 셀럽의 성별
+ * @param {string} props.profileUrl - 셀럽의 프로필 사진 URL
+ */
+
 function CelebProfile({
   celebName,
   affiliation,

--- a/src/src/components/celebrity-detail/CelebProfile.jsx
+++ b/src/src/components/celebrity-detail/CelebProfile.jsx
@@ -28,6 +28,7 @@ const Styled = {
   Img: styled.img`
     width: 9.5rem;
     border-radius: 0.25rem;
+    margin-bottom: 1rem;
   `,
 };
 

--- a/src/src/components/celebrity-detail/CelebRank.jsx
+++ b/src/src/components/celebrity-detail/CelebRank.jsx
@@ -1,0 +1,29 @@
+import FirstRibbonIcon from "@/assets/icon/FirstRibbonIcon.jsx";
+import SecondRibbonIcon from "@/assets/icon/SecondRibbonIcon.jsx";
+import ThirdRibbonIcon from "@/assets/icon/ThirdRibbonIcon.jsx";
+
+function CelebRank({ followerRank, fundingRank }) {
+  const renderIcon = (rank) => {
+    const icons = {
+      1: <FirstRibbonIcon />,
+      2: <SecondRibbonIcon />,
+      3: <ThirdRibbonIcon />,
+    };
+    return icons[rank] ? icons[rank] : `${rank}등`;
+  };
+
+  return (
+    <div className="순위">
+      <div className="팔로워순위">
+        <div>{renderIcon(followerRank)}</div>
+        <div>팔로워</div>
+      </div>
+      <div className="펀딩금액순위">
+        <div>{renderIcon(fundingRank)}</div>
+        <div>펀딩금액</div>
+      </div>
+    </div>
+  );
+}
+
+export default CelebRank;

--- a/src/src/components/celebrity-detail/CelebRank.jsx
+++ b/src/src/components/celebrity-detail/CelebRank.jsx
@@ -10,7 +10,7 @@ const Styled = {
     display: flex;
   `,
   Rank: styled.div`
-    margin: 0 0.7rem;
+    margin: 0 1rem;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -40,7 +40,13 @@ function CelebRank({ followerRank, fundingRank }) {
       2: <SecondRibbonIcon />,
       3: <ThirdRibbonIcon />,
     };
-    return icons[rank] ? icons[rank] : `${rank}등`;
+    return icons[rank] ? (
+      icons[rank]
+    ) : (
+      <div
+        style={{ marginTop: "0.85rem", marginBottom: "0.84rem" }}
+      >{`${rank}등`}</div>
+    );
   };
 
   return (

--- a/src/src/components/celebrity-detail/CelebRank.jsx
+++ b/src/src/components/celebrity-detail/CelebRank.jsx
@@ -1,6 +1,37 @@
+import { styled } from "styled-components";
+import { PropTypes } from "prop-types";
+
 import FirstRibbonIcon from "@/assets/icon/FirstRibbonIcon.jsx";
 import SecondRibbonIcon from "@/assets/icon/SecondRibbonIcon.jsx";
 import ThirdRibbonIcon from "@/assets/icon/ThirdRibbonIcon.jsx";
+
+const Styled = {
+  RankContainer: styled.div`
+    display: flex;
+  `,
+  Rank: styled.div`
+    margin: 0 0.7rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    & div {
+      margin-bottom: 0.5rem;
+      font-size: 1.5rem;
+      font-weight: 500;
+    }
+
+    & span {
+      color: ${({ theme }) => theme.color.addition};
+    }
+  `,
+};
+
+/**
+ * 셀럽순위 표시 컴포넌트 - 팔로워수, 총펀딩금액순으로 순위 표기. 1,2,3 등은 아이콘 그 외 텍스트 등수표시
+ * @param {string} props.followerRank - 팔로워 순위
+ * @param {string} props.fundingRank- 총 펀딩금액 순위
+ */
 
 function CelebRank({ followerRank, fundingRank }) {
   const renderIcon = (rank) => {
@@ -13,17 +44,22 @@ function CelebRank({ followerRank, fundingRank }) {
   };
 
   return (
-    <div className="순위">
-      <div className="팔로워순위">
+    <Styled.RankContainer>
+      <Styled.Rank>
         <div>{renderIcon(followerRank)}</div>
-        <div>팔로워</div>
-      </div>
-      <div className="펀딩금액순위">
+        <span>팔로워</span>
+      </Styled.Rank>
+      <Styled.Rank>
         <div>{renderIcon(fundingRank)}</div>
-        <div>펀딩금액</div>
-      </div>
-    </div>
+        <span>펀딩금액</span>
+      </Styled.Rank>
+    </Styled.RankContainer>
   );
 }
+
+CelebRank.propTypes = {
+  followerRank: PropTypes.number.isRequired,
+  fundingRank: PropTypes.number.isRequired,
+};
 
 export default CelebRank;

--- a/src/src/components/celebrity-detail/CelebRank.jsx
+++ b/src/src/components/celebrity-detail/CelebRank.jsx
@@ -23,6 +23,7 @@ const Styled = {
 
     & span {
       color: ${({ theme }) => theme.color.addition};
+      white-space: nowrap;
     }
   `,
 };
@@ -44,7 +45,11 @@ function CelebRank({ followerRank, fundingRank }) {
       icons[rank]
     ) : (
       <div
-        style={{ marginTop: "0.85rem", marginBottom: "0.84rem" }}
+        style={{
+          marginTop: "0.85rem",
+          marginBottom: "0.84rem",
+          whiteSpace: "nowrap",
+        }}
       >{`${rank}등`}</div>
     );
   };

--- a/src/src/components/celebrity-detail/CelebTextInfo.jsx
+++ b/src/src/components/celebrity-detail/CelebTextInfo.jsx
@@ -25,6 +25,13 @@ const Styled = {
   `,
 };
 
+/**
+ * 셀럽텍스트정보 컴포넌트 - 진행중인 펀딩개수, 총 펀딩 금액, 팔로워 수를 각각 아이콘과 함께 명시
+ * @param {number} props.fundInProgressNum - 진행 중인 펀딩 수
+ * @param {number} props.totalFundMoney - 총 펀딩 금액
+ * @param {number} props.followerNum - 팔로워 수
+ */
+
 function CelebTextInfo({ fundInProgressNum, totalFundMoney, followerNum }) {
   return (
     <Styled.TextContainer>

--- a/src/src/components/celebrity-detail/CelebTextInfo.jsx
+++ b/src/src/components/celebrity-detail/CelebTextInfo.jsx
@@ -9,12 +9,13 @@ const Styled = {
   TextContainer: styled.div`
     display: flex;
     flex-direction: column;
+    margin-top: 1.2rem;
   `,
 
   Text: styled.div`
     display: flex;
     align-items: center;
-    margin-top: 1.5rem;
+    margin-top: 1rem;
     font-size: 1rem;
     color: ${({ theme }) => theme.color.addition};
 
@@ -39,7 +40,7 @@ function CelebTextInfo({ fundInProgressNum, totalFundMoney, followerNum }) {
   return (
     <Styled.TextContainer>
       <Styled.Text>
-        <UserIcon />
+        <UserIcon size={32} />
         <span>
           <strong>{followerNum || 0}</strong>
           명이 팔로우 중
@@ -47,14 +48,14 @@ function CelebTextInfo({ fundInProgressNum, totalFundMoney, followerNum }) {
       </Styled.Text>
 
       <Styled.Text>
-        <MoneyIcon />
+        <MoneyIcon size={32} />
         <span>
           총 <strong>{totalFundMoney.toLocaleString("ko-KR") || 0}</strong>원
         </span>
       </Styled.Text>
 
       <Styled.Text>
-        <InProgressIcon />
+        <InProgressIcon size={32} />
         <span>
           <strong>{fundInProgressNum || 0}</strong>
           개의 펀딩 진행 중

--- a/src/src/components/celebrity-detail/CelebTextInfo.jsx
+++ b/src/src/components/celebrity-detail/CelebTextInfo.jsx
@@ -21,6 +21,7 @@ const Styled = {
 
     & span {
       margin-left: 0.4rem;
+      white-space: nowrap;
     }
     & strong {
       font-weight: 500;

--- a/src/src/components/celebrity-detail/CelebTextInfo.jsx
+++ b/src/src/components/celebrity-detail/CelebTextInfo.jsx
@@ -1,0 +1,55 @@
+import styled from "styled-components";
+import { PropTypes } from "prop-types";
+
+import InProgressIcon from "@/assets/icon/InProgressIcon.jsx";
+import MoneyIcon from "@/assets/icon/MoneyIcon.jsx";
+import UserIcon from "@/assets/icon/UserIcon.jsx";
+
+const Styled = {
+  TextContainer: styled.div`
+    width: calc(100% - 100px - 1rem);
+    display: flex;
+    flex-direction: column;
+  `,
+
+  Text: styled.div`
+    display: flex;
+    align-items: center;
+    margin-bottom: 0.5rem;
+    font-size: 1rem;
+    color: ${({ theme }) => theme.color.addition};
+
+    & span {
+      margin-left: 0.5rem;
+    }
+  `,
+};
+
+function CelebTextInfo({ fundInProgressNum, totalFundMoney, followerNum }) {
+  return (
+    <Styled.TextContainer>
+      <Styled.Text>
+        <InProgressIcon />
+        <span>{fundInProgressNum || 0}개의 펀딩 진행 중</span>
+      </Styled.Text>
+
+      <Styled.Text>
+        <MoneyIcon />
+        <span>총 {totalFundMoney.toLocaleString("ko-KR") || 0}원</span>
+      </Styled.Text>
+
+      <Styled.Text>
+        <UserIcon />
+        <span>팔로워 {followerNum || 0}명</span>
+      </Styled.Text>
+    </Styled.TextContainer>
+  );
+}
+
+CelebTextInfo.propTypes = {
+  fundInProgressNum: PropTypes.number,
+  totalFundMoney: PropTypes.number,
+  followerNum: PropTypes.number,
+};
+
+export default CelebTextInfo;

--- a/src/src/components/celebrity-detail/CelebTextInfo.jsx
+++ b/src/src/components/celebrity-detail/CelebTextInfo.jsx
@@ -14,12 +14,16 @@ const Styled = {
   Text: styled.div`
     display: flex;
     align-items: center;
-    margin-bottom: 0.5rem;
+    margin-top: 1.5rem;
     font-size: 1rem;
     color: ${({ theme }) => theme.color.addition};
 
     & span {
-      margin-left: 0.5rem;
+      margin-left: 0.4rem;
+    }
+    & strong {
+      font-weight: 500;
+      color: ${({ theme }) => theme.color.body};
     }
   `,
 };
@@ -35,18 +39,26 @@ function CelebTextInfo({ fundInProgressNum, totalFundMoney, followerNum }) {
   return (
     <Styled.TextContainer>
       <Styled.Text>
-        <InProgressIcon />
-        <span>{fundInProgressNum || 0}개의 펀딩 진행 중</span>
+        <UserIcon />
+        <span>
+          <strong>{followerNum || 0}</strong>
+          명이 팔로우 중
+        </span>
       </Styled.Text>
 
       <Styled.Text>
         <MoneyIcon />
-        <span>총 {totalFundMoney.toLocaleString("ko-KR") || 0}원</span>
+        <span>
+          총 <strong>{totalFundMoney.toLocaleString("ko-KR") || 0}</strong>원
+        </span>
       </Styled.Text>
 
       <Styled.Text>
-        <UserIcon />
-        <span>팔로워 {followerNum || 0}명</span>
+        <InProgressIcon />
+        <span>
+          <strong>{fundInProgressNum || 0}</strong>
+          개의 펀딩 진행 중
+        </span>
       </Styled.Text>
     </Styled.TextContainer>
   );

--- a/src/src/components/celebrity-detail/CelebTextInfo.jsx
+++ b/src/src/components/celebrity-detail/CelebTextInfo.jsx
@@ -7,7 +7,6 @@ import UserIcon from "@/assets/icon/UserIcon.jsx";
 
 const Styled = {
   TextContainer: styled.div`
-    width: calc(100% - 100px - 1rem);
     display: flex;
     flex-direction: column;
   `,

--- a/src/src/pages/CelebrityDetail.page.jsx
+++ b/src/src/pages/CelebrityDetail.page.jsx
@@ -22,7 +22,7 @@ function CelebrityDetailPage() {
   const celebInfo = {
     celebId: 1,
     celebName: "손흥민",
-    affiliation: "토트넘",
+    celebGroup: "토트넘",
     celebGender: "남",
     celebCategory: "스포츠",
     profileUrl:
@@ -78,7 +78,7 @@ function CelebrityDetailPage() {
       >
         <CelebProfile
           celebName={celebInfo.celebName}
-          affiliation={celebInfo.affiliation}
+          celebGroup={celebInfo.celebGroup}
           celebCategory={celebInfo.celebCategory}
           celebGender={celebInfo.celebGender}
           profileUrl={celebInfo.profileUrl}

--- a/src/src/pages/CelebrityDetail.page.jsx
+++ b/src/src/pages/CelebrityDetail.page.jsx
@@ -10,6 +10,24 @@ import FundInfoGridCard from "@/components/fund/FundInfoGridCard";
 import { GridTemplate } from "@/styles/CommonStyle";
 
 const Styled = {
+  CelebInfoContainer: styled.div`
+    display: flex;
+    align-items: center;
+    padding: 6rem 11rem 6.5rem;
+    justify-content: space-between;
+
+    @media (max-width: 912px) {
+      flex-direction: column;
+    }
+  `,
+
+  FollowButton: styled.div`
+    @media (max-width: 912px) {
+      position: absolute;
+      top: 30rem;
+    }
+  `,
+
   TextInfoContainer: styled.div`
     display: flex;
     flex-direction: column;
@@ -67,15 +85,7 @@ function CelebrityDetailPage() {
 
   return (
     <>
-      <div
-        className="셀럽정보"
-        style={{
-          display: "flex",
-          alignItems: "center",
-          padding: "6rem 11rem 6.5rem",
-          justifyContent: "space-between",
-        }}
-      >
+      <Styled.CelebInfoContainer>
         <CelebProfile
           celebName={celebInfo.celebName}
           celebGroup={celebInfo.celebGroup}
@@ -90,16 +100,18 @@ function CelebrityDetailPage() {
         />
 
         <Styled.TextInfoContainer>
-          <FollowButton
-            celebId={celebInfo.celebId}
-            isFollowing={celebInfo.isFollowing}
-            style={{
-              padding: "0.8rem 3.25rem",
-              fontSize: "1rem",
-              position: "absolute",
-              top: "10rem",
-            }}
-          />
+          <Styled.FollowButton>
+            <FollowButton
+              celebId={celebInfo.celebId}
+              isFollowing={celebInfo.isFollowing}
+              style={{
+                padding: "0.8rem 3.8rem",
+                fontSize: "1rem",
+                position: "absolute",
+                top: "10rem",
+              }}
+            />
+          </Styled.FollowButton>
           <CelebTextInfo
             fundInProgressNum={celebInfo.fundInProgressNum}
             followerNum={celebInfo.followerNum}
@@ -107,7 +119,7 @@ function CelebrityDetailPage() {
             totalFundMoney={celebInfo.totalFundMoney}
           />
         </Styled.TextInfoContainer>
-      </div>
+      </Styled.CelebInfoContainer>
 
       <div className="셀럽관련펀딩정보">
         <Tabs tabInfoArray={tabInfoArray} style={{ paddingBottom: "1rem" }} />

--- a/src/src/pages/CelebrityDetail.page.jsx
+++ b/src/src/pages/CelebrityDetail.page.jsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import CelebTextInfo from "@/components/celebrity-detail/celebTextInfo.jsx";
 import FollowButton from "@/components/celebrity/FollowButton.jsx";
 import { GridTemplate } from "@/styles/CommonStyle";
+import CelebProfile from "@/components/celebrity-detail/CelebProfile.jsx";
 
 const Styled = {
   TextInfoContainer: styled.div``,
@@ -12,6 +13,9 @@ function CelebrityDetailPage() {
   const celebInfo = {
     celebId: 1,
     celebName: "손흥민",
+    affiliation: "토트넘",
+    celebGender: "남",
+    celebCategory: "스포츠",
     profileUrl:
       "https://pds.joongang.co.kr/news/component/htmlphoto_mmdata/202308/13/3756de8c-1ea6-4988-b063-25f26d9b76d5.jpg",
     fundInProgressNum: 30,
@@ -24,17 +28,14 @@ function CelebrityDetailPage() {
   return (
     <>
       <div className="셀럽정보">
-        <div className="프로필">
-          <>
-            <span>셀럽이름</span>
-            <span>소속그룹(있으면 렌더링)</span>
-          </>
-          <>
-            <span>분류</span>
-            <span> . </span>
-            <span>성별</span>
-          </>
-        </div>
+        <CelebProfile
+          celebName={celebInfo.celebName}
+          affiliation={celebInfo.affiliation}
+          celebCategory={celebInfo.celebCategory}
+          celebGender={celebInfo.celebGender}
+          profileUrl={celebInfo.profileUrl}
+        />
+
         <div className="순위">
           <>
             <div>뱃지아이콘</div>

--- a/src/src/pages/CelebrityDetail.page.jsx
+++ b/src/src/pages/CelebrityDetail.page.jsx
@@ -1,10 +1,13 @@
+import { useState } from "react";
 import styled from "styled-components";
 
 import CelebTextInfo from "@/components/celebrity-detail/celebTextInfo.jsx";
 import FollowButton from "@/components/celebrity/FollowButton.jsx";
-import { GridTemplate } from "@/styles/CommonStyle";
 import CelebProfile from "@/components/celebrity-detail/CelebProfile.jsx";
 import CelebRank from "@/components/celebrity-detail/CelebRank.jsx";
+import Tabs from "@/components/common/button/TabButtons.jsx";
+import FundInfoGridCard from "@/components/fund/FundInfoGridCard";
+import { GridTemplate } from "@/styles/CommonStyle";
 
 const Styled = {
   TextInfoContainer: styled.div`
@@ -14,6 +17,8 @@ const Styled = {
 };
 
 function CelebrityDetailPage() {
+  const [selectedTab, setSelectedTab] = useState(0);
+
   const celebInfo = {
     celebId: 1,
     celebName: "손흥민",
@@ -31,6 +36,34 @@ function CelebrityDetailPage() {
       fundMoney: 3,
     },
   };
+
+  const fundInfo = {
+    fundId: 1,
+    fundTitle:
+      "손흥민 주장된 기념 지하철 광고 🎉🎉 축구중독자가 책임지고 펀딩합니다 ❤️‍🔥",
+    thumbnailUrl:
+      "https://ichef.bbci.co.uk/news/640/cpsprodpb/4118/production/_119546661_gettyimages-1294130887.jpg",
+    targetDate: "2023-12-17",
+    targetMoney: "3000000",
+    currentMoney: "2340000",
+    celebrityId: "sonny",
+    celebrityName: "손흥민",
+    celebrityProfileUrl:
+      "https://pds.joongang.co.kr/news/component/htmlphoto_mmdata/202308/13/3756de8c-1ea6-4988-b063-25f26d9b76d5.jpg",
+    organizerId: "soccer123",
+    organizerName: "축구도사",
+  };
+
+  const tabInfoArray = [
+    {
+      title: "진행중 펀딩",
+      func: () => setSelectedTab(0),
+    },
+    {
+      title: "마감된 펀딩",
+      func: () => setSelectedTab(1),
+    },
+  ];
 
   return (
     <>
@@ -77,11 +110,24 @@ function CelebrityDetailPage() {
       </div>
 
       <div className="셀럽관련펀딩정보">
-        <div>Tabs</div>
+        <Tabs tabInfoArray={tabInfoArray} style={{ paddingBottom: "1rem" }} />
         <GridTemplate>
-          <div>셀럽인포카드</div>
-          <div>셀럽인포카드</div>
-          <div>셀럽인포카드</div>
+          {new Array(6).fill(fundInfo).map((info, index) => (
+            <FundInfoGridCard
+              key={index}
+              fundId={fundInfo.fundId}
+              fundTitle={fundInfo.fundTitle}
+              thumbnailUrl={fundInfo.thumbnailUrl}
+              targetDate={fundInfo.targetDate}
+              targetMoney={fundInfo.targetMoney}
+              currentMoney={fundInfo.currentMoney}
+              celebrityId={fundInfo.celebrityId}
+              celebrityProfileUrl={fundInfo.celebrityProfileUrl}
+              celebrityName={fundInfo.celebrityName}
+              organizerId={fundInfo.organizerId}
+              organizerName={fundInfo.organizerName}
+            />
+          ))}
         </GridTemplate>
       </div>
     </>

--- a/src/src/pages/CelebrityDetail.page.jsx
+++ b/src/src/pages/CelebrityDetail.page.jsx
@@ -33,7 +33,7 @@ function CelebrityDetailPage() {
     isFollowing: false,
     rank: {
       follower: 1,
-      fundMoney: 3,
+      fundMoney: 4,
     },
   };
 

--- a/src/src/pages/CelebrityDetail.page.jsx
+++ b/src/src/pages/CelebrityDetail.page.jsx
@@ -1,6 +1,26 @@
+import styled from "styled-components";
+
+import CelebTextInfo from "@/components/celebrity-detail/celebTextInfo.jsx";
+import FollowButton from "@/components/celebrity/FollowButton.jsx";
 import { GridTemplate } from "@/styles/CommonStyle";
 
+const Styled = {
+  TextInfoContainer: styled.div``,
+};
+
 function CelebrityDetailPage() {
+  const celebInfo = {
+    celebId: 1,
+    celebName: "손흥민",
+    profileUrl:
+      "https://pds.joongang.co.kr/news/component/htmlphoto_mmdata/202308/13/3756de8c-1ea6-4988-b063-25f26d9b76d5.jpg",
+    fundInProgressNum: 30,
+    totalFundMoney: 35000000,
+    followerNum: 10000,
+    isFollowing: false,
+    rank: 1,
+  };
+
   return (
     <>
       <div className="셀럽정보">
@@ -25,24 +45,22 @@ function CelebrityDetailPage() {
             <div>펀딩금액</div>
           </>
         </div>
-        <div className="텍스트정보">
-          <button>팔로우버튼</button>
-          <div className="텍스트컨테이너">
-            <div>
-              <div>아이콘</div>
-              <div>몇명팔로우중</div>
-            </div>
-            <div>
-              <div>아이콘</div>
-              <div>총 금액</div>
-            </div>
-            <div>
-              <div>아이콘</div>
-              <div>몇개 펀딩진행중</div>
-            </div>
-          </div>
-        </div>
+
+        <Styled.TextInfoContainer>
+          <FollowButton
+            celebId={celebInfo.celebId}
+            isFollowing={celebInfo.isFollowing}
+            style={{ padding: "10px 14px", fontSize: "1rem" }}
+          />
+          <CelebTextInfo
+            fundInProgressNum={celebInfo.fundInProgressNum}
+            followerNum={celebInfo.followerNum}
+            isFollowing={celebInfo.isFollowing}
+            totalFundMoney={celebInfo.totalFundMoney}
+          />
+        </Styled.TextInfoContainer>
       </div>
+
       <div className="셀럽관련펀딩정보">
         <div>Tabs</div>
         <GridTemplate>

--- a/src/src/pages/CelebrityDetail.page.jsx
+++ b/src/src/pages/CelebrityDetail.page.jsx
@@ -63,6 +63,8 @@ function CelebrityDetailPage() {
             style={{
               padding: "0.8rem 3.25rem",
               fontSize: "1rem",
+              position: "absolute",
+              top: "10rem",
             }}
           />
           <CelebTextInfo

--- a/src/src/pages/CelebrityDetail.page.jsx
+++ b/src/src/pages/CelebrityDetail.page.jsx
@@ -1,5 +1,58 @@
+import { GridTemplate } from "@/styles/CommonStyle";
+
 function CelebrityDetailPage() {
-  return <div>셀럽 상세페이지</div>;
+  return (
+    <>
+      <div className="셀럽정보">
+        <div className="프로필">
+          <>
+            <span>셀럽이름</span>
+            <span>소속그룹(있으면 렌더링)</span>
+          </>
+          <>
+            <span>분류</span>
+            <span> . </span>
+            <span>성별</span>
+          </>
+        </div>
+        <div className="순위">
+          <>
+            <div>뱃지아이콘</div>
+            <div>팔로워</div>
+          </>
+          <>
+            <div>뱃지아이콘</div>
+            <div>펀딩금액</div>
+          </>
+        </div>
+        <div className="텍스트정보">
+          <button>팔로우버튼</button>
+          <div className="텍스트컨테이너">
+            <div>
+              <div>아이콘</div>
+              <div>몇명팔로우중</div>
+            </div>
+            <div>
+              <div>아이콘</div>
+              <div>총 금액</div>
+            </div>
+            <div>
+              <div>아이콘</div>
+              <div>몇개 펀딩진행중</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="셀럽관련펀딩정보">
+        <div>Tabs</div>
+        <GridTemplate>
+          <div>셀럽인포카드</div>
+          <div>셀럽인포카드</div>
+          <div>셀럽인포카드</div>
+        </GridTemplate>
+      </div>
+    </>
+  );
 }
 
 export default CelebrityDetailPage;

--- a/src/src/pages/CelebrityDetail.page.jsx
+++ b/src/src/pages/CelebrityDetail.page.jsx
@@ -7,7 +7,10 @@ import CelebProfile from "@/components/celebrity-detail/CelebProfile.jsx";
 import CelebRank from "@/components/celebrity-detail/CelebRank.jsx";
 
 const Styled = {
-  TextInfoContainer: styled.div``,
+  TextInfoContainer: styled.div`
+    display: flex;
+    flex-direction: column;
+  `,
 };
 
 function CelebrityDetailPage() {
@@ -35,7 +38,8 @@ function CelebrityDetailPage() {
         className="셀럽정보"
         style={{
           display: "flex",
-          margin: "6.8rem 11rem 6.5rem",
+          alignItems: "center",
+          padding: "6rem 11rem 6.5rem",
           justifyContent: "space-between",
         }}
       >
@@ -56,7 +60,10 @@ function CelebrityDetailPage() {
           <FollowButton
             celebId={celebInfo.celebId}
             isFollowing={celebInfo.isFollowing}
-            style={{ padding: "10px 14px", fontSize: "1rem" }}
+            style={{
+              padding: "0.8rem 3.25rem",
+              fontSize: "1rem",
+            }}
           />
           <CelebTextInfo
             fundInProgressNum={celebInfo.fundInProgressNum}

--- a/src/src/pages/CelebrityDetail.page.jsx
+++ b/src/src/pages/CelebrityDetail.page.jsx
@@ -18,6 +18,9 @@ const Styled = {
 
     @media (max-width: 912px) {
       flex-direction: column;
+      padding-left: 0;
+      padding-right: 0;
+      width: 100%;
     }
   `,
 

--- a/src/src/pages/CelebrityDetail.page.jsx
+++ b/src/src/pages/CelebrityDetail.page.jsx
@@ -4,6 +4,7 @@ import CelebTextInfo from "@/components/celebrity-detail/celebTextInfo.jsx";
 import FollowButton from "@/components/celebrity/FollowButton.jsx";
 import { GridTemplate } from "@/styles/CommonStyle";
 import CelebProfile from "@/components/celebrity-detail/CelebProfile.jsx";
+import CelebRank from "@/components/celebrity-detail/CelebRank.jsx";
 
 const Styled = {
   TextInfoContainer: styled.div``,
@@ -22,12 +23,22 @@ function CelebrityDetailPage() {
     totalFundMoney: 35000000,
     followerNum: 10000,
     isFollowing: false,
-    rank: 1,
+    rank: {
+      follower: 1,
+      fundMoney: 3,
+    },
   };
 
   return (
     <>
-      <div className="셀럽정보">
+      <div
+        className="셀럽정보"
+        style={{
+          display: "flex",
+          margin: "6.8rem 11rem 6.5rem",
+          justifyContent: "space-between",
+        }}
+      >
         <CelebProfile
           celebName={celebInfo.celebName}
           affiliation={celebInfo.affiliation}
@@ -36,16 +47,10 @@ function CelebrityDetailPage() {
           profileUrl={celebInfo.profileUrl}
         />
 
-        <div className="순위">
-          <>
-            <div>뱃지아이콘</div>
-            <div>팔로워</div>
-          </>
-          <>
-            <div>뱃지아이콘</div>
-            <div>펀딩금액</div>
-          </>
-        </div>
+        <CelebRank
+          followerRank={celebInfo.rank.follower}
+          fundingRank={celebInfo.rank.fundMoney}
+        />
 
         <Styled.TextInfoContainer>
           <FollowButton


### PR DESCRIPTION
## 주요 사항
- 셀럽상세페이지
- 셀럽정보와, 셀럽관련펀딩정보로 나눠서 작업
- 팔로워, 펀딩금액 순위가 1~3에 들지 않는 경우 텍스트로 등수 표시
- 미해결 이슈
1️⃣ 셀럽정보(윗부분)부분이 모바일 사이즈에 맞춰지지 않았다는점
2️⃣ 아이콘과 텍스트 등수가 같이 존재할때 둘 비율이 잘 맞지 않는 점 ex) 1등 4등 
3️⃣ 텍스트정보에 아이콘 크기조절

## 스크린샷
<img width="1198" alt="스크린샷 2023-10-28 오후 6 23 32" src="https://github.com/Step3-kakao-tech-campus/Team13_FE/assets/124874266/9dc6e22c-6bca-40de-9a5e-4c4498e66f3c">

<img width="1146" alt="스크린샷 2023-10-28 오후 6 24 08" src="https://github.com/Step3-kakao-tech-campus/Team13_FE/assets/124874266/b7efba8c-a352-47d4-a645-51658d1f256d">



## 궁금한 점
아직 데이터 가져오는 부분을 생각하지 않아서 일단 임시로  info로 다 넣어버리고 작업했는데 이부분은 추후에 수정하도록하겠습니다!
이부분에 대해서 리뷰해주실 점 있으시면 말씀해주세요!
창 줄이면 자동으로 조절이 되어야하는데 상단부분이 안되는거 같습니다. 무엇이 문제일까요?
미해결 이슈에 관해서 잘 봐주시면 감사하겠습니다.😃(전체적으로 스타일 적용된 부분도요!)

### 관련 이슈
close #76 
