### PR TITLE
펀딩 상세 페이지 출금 UI, mock api 

### DIFF
--- a/src/src/api/fundAPI.js
+++ b/src/src/api/fundAPI.js
@@ -100,6 +100,29 @@ const getFundWithdrawInfo = async ({ fundId, pageIndex }) => {
   });
 };
 
+/**
+ * 출금 인증 이미지 저장하기
+ * @param {string || number} fundId
+ * @param {string || number} withdrawId
+ * @param {FormData} imageForm
+ * @returns {Promise<*>}
+ */
+
+const postFundWithdrawEvidenceImage = async ({
+  fundId,
+  withdrawId,
+  imageForm,
+}) => {
+  return await instance({
+    url: API.FUND.WITHDRAW_IMAGE({ fundId, withdrawId }),
+    method: "POST",
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+    data: imageForm,
+  });
+};
+
 export default {
   getFundInfoList,
   postFundLike,
@@ -108,4 +131,5 @@ export default {
   getFundIntroductionByFundId,
   getDetailInfoByFundId,
   getFundWithdrawInfo,
+  postFundWithdrawEvidenceImage,
 };

--- a/src/src/api/fundAPI.js
+++ b/src/src/api/fundAPI.js
@@ -86,6 +86,20 @@ const getFundIntroductionByFundId = async (fundId) => {
   return new FundIntroDto({ introduction: data.introduction });
 };
 
+/**
+ * 펀딩 출금 내역 조회
+ * @param {string || number} fundId
+ * @param {number} pageIndex
+ * @returns {Promise<axios.AxiosResponse<any>>}
+ */
+const getFundWithdrawInfo = async ({ fundId, pageIndex }) => {
+  return await instance({
+    url: API.FUND.WITHDRAW(fundId),
+    method: "GET",
+    params: { pageIndex: pageIndex },
+  });
+};
+
 export default {
   getFundInfoList,
   postFundLike,
@@ -93,4 +107,5 @@ export default {
   getCoAdminByFundId,
   getFundIntroductionByFundId,
   getDetailInfoByFundId,
+  getFundWithdrawInfo,
 };

--- a/src/src/api/fundAPI.js
+++ b/src/src/api/fundAPI.js
@@ -49,6 +49,12 @@ const deleteFundLike = async (fundId) => {
   });
 };
 
+/**
+ * 펀딩 상세 정보 조회
+ * @param {number | string }fundId
+ * @returns {Promise<FundDetailInfoDto>}
+ */
+
 const getDetailInfoByFundId = async (fundId) => {
   const { data } = await instance({
     url: API.FUND.DETAIL(fundId),

--- a/src/src/components/common/button/ImagePreviewButton.jsx
+++ b/src/src/components/common/button/ImagePreviewButton.jsx
@@ -58,8 +58,8 @@ const Styled = {
 /**
  * 미리보기 이미지 파일 input
  * @param {string} imageUrl 이미지 url
- * @param {func} handleFileChange 이미지 파일 변경 핸들러
- * @param {func} handleFileDelete 이미지 파일 삭제 핸들러
+ * @param {function} handleFileChange 이미지 파일 변경 핸들러
+ * @param {function} handleFileDelete 이미지 파일 삭제 핸들러
  * @param {object} containerStyle
  * @param {string} imageAspectRatio
  */

--- a/src/src/components/fund-detail/DynamicDetailRender.jsx
+++ b/src/src/components/fund-detail/DynamicDetailRender.jsx
@@ -21,7 +21,7 @@ function DynamicDetailRender({ type, isOrganizer }) {
     case TABS.FUND_DETAIL.COMMENT:
       return <Comment />;
     case TABS.FUND_DETAIL.WITHDRAW:
-      return <Withdraw />;
+      return <Withdraw isOrganizer={isOrganizer} />;
     default:
       return <div>잘못 선택되었습니다 다시 선택해 주세요</div>;
   }

--- a/src/src/components/fund-detail/DynamicDetailRender.jsx
+++ b/src/src/components/fund-detail/DynamicDetailRender.jsx
@@ -2,9 +2,9 @@ import { PropTypes } from "prop-types";
 
 import TABS from "@/constants/TABS.js";
 import Introduction from "@/components/fund-detail/introduction/Introduction.jsx";
-import Update from "@/components/fund-detail/update/index.jsx";
-import Comment from "@/components/fund-detail/comment/index.jsx";
-import Index from "@/components/fund-detail/withdraw/index.jsx";
+import Update from "@/components/fund-detail/update/Update.jsx";
+import Comment from "@/components/fund-detail/comment/Comment.jsx";
+import Withdraw from "@/components/fund-detail/withdraw/Withdraw.jsx";
 
 /**
  * 펀딩 상세 페이지 탭 버튼 선택에 따른 하단 컴포넌트 변경
@@ -21,7 +21,7 @@ function DynamicDetailRender({ type, isOrganizer }) {
     case TABS.FUND_DETAIL.COMMENT:
       return <Comment />;
     case TABS.FUND_DETAIL.WITHDRAW:
-      return <Index />;
+      return <Withdraw />;
     default:
       return <div>잘못 선택되었습니다 다시 선택해 주세요</div>;
   }

--- a/src/src/components/fund-detail/comment/Comment.jsx
+++ b/src/src/components/fund-detail/comment/Comment.jsx
@@ -1,0 +1,4 @@
+function Comment() {
+  return <div>댓글창</div>;
+}
+export default Comment;

--- a/src/src/components/fund-detail/comment/index.jsx
+++ b/src/src/components/fund-detail/comment/index.jsx
@@ -1,4 +1,0 @@
-function Index() {
-  return <div>댓글창</div>;
-}
-export default Index;

--- a/src/src/components/fund-detail/information/Information.jsx
+++ b/src/src/components/fund-detail/information/Information.jsx
@@ -9,6 +9,8 @@ import Button from "@/components/common/button/Button.jsx";
 import FundDetailInfoHeartButton from "@/components/fund-detail/information/FundDetailInfoHeartButton.jsx";
 import AlertIcon from "@/assets/icon/AlertIcon.jsx";
 import SimpleCelebCard from "@/components/celebrity/SimpleCelebCard.jsx";
+import { useEffect } from "react";
+import { PropTypes } from "prop-types";
 
 const Styled = {
   InfoWrap: styled.article`
@@ -105,10 +107,20 @@ const Styled = {
   `,
 };
 
-function Information() {
+/**
+ * 펀딩 상세 페이지의 펀딩 정보 컴포넌트
+ * @param {function} setIsOrganizer
+ */
+
+function Information({ setIsOrganizer }) {
   const navigate = useNavigate();
   const { fundId } = useParams();
   const { data } = useFundDetailInfoQuery({ fundId: fundId });
+  const { isOrganizer } = data;
+
+  useEffect(() => {
+    setIsOrganizer(isOrganizer);
+  }, [isOrganizer]);
 
   const handleSponsorshipButtonClick = () => {
     navigate(`${routes.support}/${fundId}`);
@@ -184,5 +196,9 @@ function Information() {
     </Styled.InfoWrap>
   );
 }
+
+Information.propTypes = {
+  setIsOrganizer: PropTypes.func,
+};
 
 export default Information;

--- a/src/src/components/fund-detail/update/Update.jsx
+++ b/src/src/components/fund-detail/update/Update.jsx
@@ -1,0 +1,5 @@
+function Update() {
+  return <div>업데이트</div>;
+}
+
+export default Update;

--- a/src/src/components/fund-detail/update/index.jsx
+++ b/src/src/components/fund-detail/update/index.jsx
@@ -1,5 +1,0 @@
-function Index() {
-  return <div>업데이트</div>;
-}
-
-export default Index;

--- a/src/src/components/fund-detail/withdraw/EvidenceIcon.jsx
+++ b/src/src/components/fund-detail/withdraw/EvidenceIcon.jsx
@@ -1,0 +1,23 @@
+import styled from "styled-components";
+
+const Styled = {
+  Container: styled.div`
+    width: 2rem;
+    height: 2rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: ${({ theme }) => theme.color.kakaoYellow};
+    font-size: 1.25rem;
+    font-weight: 600;
+    border-radius: 9999px;
+    border: 6px solid ${({ theme }) => theme.color.kakaoYellow};
+    background-color: ${({ theme }) => theme.color.white};
+  `,
+};
+
+function EvidenceIcon() {
+  return <Styled.Container>f</Styled.Container>;
+}
+
+export default EvidenceIcon;

--- a/src/src/components/fund-detail/withdraw/EvidenceModal.jsx
+++ b/src/src/components/fund-detail/withdraw/EvidenceModal.jsx
@@ -3,6 +3,8 @@ import styled from "styled-components";
 import ImagePreviewButton from "@/components/common/button/ImagePreviewButton.jsx";
 import useSetImageFileToUrl from "@/hooks/useSetImageFileToUrl.js";
 import { PropTypes } from "prop-types";
+import useFundWithdrawEvidenceImageMutation from "@/hooks/api/fund/useFundWithdrawEvidenceImageMutation.js";
+import { useParams } from "react-router-dom";
 
 const Styled = {
   Container: styled.div`
@@ -44,17 +46,30 @@ const Styled = {
 
 /**
  * 증명내역을 자세히 볼 수 있는 모달창
+ * @param {number} withdrawId
  * @param {boolean} isOrganizer
  * @param {string} title
  * @param {string} evidenceImgUrl
  * @param {function} setOpen
  */
 
-function EvidenceModal({ isOrganizer, title, evidenceImgUrl, setOpen }) {
+function EvidenceModal({
+  withdrawId,
+  isOrganizer,
+  title,
+  evidenceImgUrl,
+  setOpen,
+}) {
+  const { fundId } = useParams();
+
   const { file, imageUrl, handleFileChange, handleFileDelete } =
     useSetImageFileToUrl(evidenceImgUrl);
 
-  // TODO: 증명내역 이미지 등록하는 api 통신 추가
+  const { mutate } = useFundWithdrawEvidenceImageMutation({
+    fundId,
+    withdrawId,
+  });
+
   return (
     <BackdropModal setOpen={setOpen}>
       <Styled.Container>
@@ -70,8 +85,14 @@ function EvidenceModal({ isOrganizer, title, evidenceImgUrl, setOpen }) {
         {isOrganizer ? (
           <ImagePreviewButton
             imageUrl={imageUrl}
-            handleFileDelete={handleFileDelete}
-            handleFileChange={handleFileChange}
+            handleFileDelete={(e) => {
+              handleFileDelete(e);
+              mutate({ image: null });
+            }}
+            handleFileChange={(e) => {
+              handleFileChange(e);
+              mutate({ image: file });
+            }}
             imageAspectRatio={null}
             containerStyle={{ maxWidth: "80vw" }}
           />
@@ -84,9 +105,10 @@ function EvidenceModal({ isOrganizer, title, evidenceImgUrl, setOpen }) {
 }
 
 EvidenceModal.propTypes = {
+  withdrawId: PropTypes.number,
   isOrganizer: PropTypes.bool,
   title: PropTypes.string,
-  evidenceUrl: PropTypes.string,
+  evidenceImgUrl: PropTypes.string,
   setOpen: PropTypes.func,
 };
 

--- a/src/src/components/fund-detail/withdraw/EvidenceModal.jsx
+++ b/src/src/components/fund-detail/withdraw/EvidenceModal.jsx
@@ -1,0 +1,93 @@
+import BackdropModal from "@/components/common/modal/BackdropModal.jsx";
+import styled from "styled-components";
+import ImagePreviewButton from "@/components/common/button/ImagePreviewButton.jsx";
+import useSetImageFileToUrl from "@/hooks/useSetImageFileToUrl.js";
+import { PropTypes } from "prop-types";
+
+const Styled = {
+  Container: styled.div`
+    padding: 0 2rem;
+    min-width: 20rem;
+    min-height: 10rem;
+
+    label {
+      min-height: 10rem;
+    }
+  `,
+
+  Title: styled.div`
+    font-size: 1.5rem;
+    font-weight: 600;
+  `,
+
+  OrganizerText: styled.div`
+    padding-top: 2rem;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+
+    .bold {
+      font-size: 1.25rem;
+      font-weight: 600;
+      padding-bottom: 0.5rem;
+    }
+  `,
+
+  UserImage: styled.img`
+    margin-top: 1rem;
+    min-height: 10rem;
+    max-width: 80vw;
+  `,
+};
+
+/**
+ * 증명내역을 자세히 볼 수 있는 모달창
+ * @param {boolean} isOrganizer
+ * @param {string} title
+ * @param {string} evidenceImgUrl
+ * @param {function} setOpen
+ */
+
+function EvidenceModal({ isOrganizer, title, evidenceImgUrl, setOpen }) {
+  const { file, imageUrl, handleFileChange, handleFileDelete } =
+    useSetImageFileToUrl(evidenceImgUrl);
+
+  // TODO: 증명내역 이미지 등록하는 api 통신 추가
+  return (
+    <BackdropModal setOpen={setOpen}>
+      <Styled.Container>
+        <Styled.Title>{title}</Styled.Title>
+        {isOrganizer && (
+          <Styled.OrganizerText>
+            <div className="bold">
+              증명가능한 내역을 아래에 첨부해주세요 (예시: 영수증)
+            </div>
+            <div>전체 내용이 모두 보이게 선명하게 촬영해주세요!</div>
+          </Styled.OrganizerText>
+        )}
+        {isOrganizer ? (
+          <ImagePreviewButton
+            imageUrl={imageUrl}
+            handleFileDelete={handleFileDelete}
+            handleFileChange={handleFileChange}
+            imageAspectRatio={null}
+            containerStyle={{ maxWidth: "80vw" }}
+          />
+        ) : (
+          <Styled.UserImage src={evidenceImgUrl} alt={""} />
+        )}
+      </Styled.Container>
+    </BackdropModal>
+  );
+}
+
+EvidenceModal.propTypes = {
+  isOrganizer: PropTypes.bool,
+  title: PropTypes.string,
+  evidenceUrl: PropTypes.string,
+  setOpen: PropTypes.func,
+};
+
+export default EvidenceModal;

--- a/src/src/components/fund-detail/withdraw/InfiniteWithdrawInfo.jsx
+++ b/src/src/components/fund-detail/withdraw/InfiniteWithdrawInfo.jsx
@@ -1,0 +1,77 @@
+import { useRef } from "react";
+import { useParams } from "react-router-dom";
+import styled from "styled-components";
+import useInfiniteWithdrawInfoQuery from "@/hooks/api/fund/useInfiniteWithdrawInfoQuery.js";
+import useIntersectionObserver from "@/hooks/useIntersectionObserver.js";
+import WithdrawInfoBar from "@/components/fund-detail/withdraw/WithdrawInfoBar.jsx";
+import InfiniteWithdrawInfoLoader from "@/components/fund-detail/withdraw/InfiniteWithdrawInfo.loader.jsx";
+import { PropTypes } from "prop-types";
+
+const Styled = {
+  TotalMoneyBar: styled.div`
+    padding: 1.5rem 0 1rem 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: ${({ theme }) => theme.border.strong};
+
+    font-size: 1.25rem;
+    font-weight: 600;
+    .left-money {
+      color: ${({ theme }) => theme.color.mainRed};
+    }
+  `,
+};
+
+/**
+ * 출금 내역 무한스크롤
+ * @param {boolean} isOrganizer
+ */
+
+function InfiniteWithdrawInfo({ isOrganizer }) {
+  const { fundId } = useParams();
+  const loaderRef = useRef();
+
+  const { data: withdrawInfoData, fetchNextPage } =
+    useInfiniteWithdrawInfoQuery({ fundId });
+
+  useIntersectionObserver(async () => {
+    await fetchNextPage();
+  }, loaderRef);
+
+  return (
+    <>
+      <Styled.TotalMoneyBar>
+        <div className="description">남은 금액</div>
+        <div className="left-money">
+          {withdrawInfoData?.pages[0]?.data?.currentBalance?.toLocaleString(
+            "ko-KR",
+          )}
+          원
+        </div>
+      </Styled.TotalMoneyBar>
+      {withdrawInfoData?.pages?.map((page) =>
+        page?.data?.withdrawalDTOs.map((info, index) => (
+          <WithdrawInfoBar
+            key={index}
+            isOrganizer={isOrganizer}
+            id={info?.withdrawId}
+            date={new Date(info?.withdrawTime)}
+            usageTitle={info?.usage}
+            evidenceUrl={info?.evidenceUrl}
+            withdrawMoney={info?.withdrawAmount}
+            totalMoney={info?.balance}
+          />
+        )),
+      )}
+
+      <InfiniteWithdrawInfoLoader loaderRef={loaderRef} />
+    </>
+  );
+}
+
+InfiniteWithdrawInfo.propTypes = {
+  isOrganizer: PropTypes.bool,
+};
+
+export default InfiniteWithdrawInfo;

--- a/src/src/components/fund-detail/withdraw/InfiniteWithdrawInfo.loader.jsx
+++ b/src/src/components/fund-detail/withdraw/InfiniteWithdrawInfo.loader.jsx
@@ -1,0 +1,22 @@
+import WithdrawInfoBarSkeleton from "@/components/fund-detail/withdraw/WithdrawInfoBar.skeleton.jsx";
+import { PropTypes } from "prop-types";
+
+/**
+ * 무한스크롤 출금 내역 로더
+ * @param {React.RefObject} loaderRef
+ */
+
+function InfiniteWithdrawInfoLoader({ loaderRef }) {
+  return (
+    <div ref={loaderRef}>
+      <WithdrawInfoBarSkeleton />
+      <WithdrawInfoBarSkeleton />
+    </div>
+  );
+}
+
+InfiniteWithdrawInfoLoader.propTypes = {
+  loaderRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+};
+
+export default InfiniteWithdrawInfoLoader;

--- a/src/src/components/fund-detail/withdraw/Withdraw.jsx
+++ b/src/src/components/fund-detail/withdraw/Withdraw.jsx
@@ -1,0 +1,5 @@
+function Withdraw() {
+  return <div>출금하기</div>;
+}
+
+export default Withdraw;

--- a/src/src/components/fund-detail/withdraw/Withdraw.jsx
+++ b/src/src/components/fund-detail/withdraw/Withdraw.jsx
@@ -1,6 +1,8 @@
 import styled from "styled-components";
 import Button from "@/components/common/button/Button.jsx";
 import WithdrawInfoBar from "@/components/fund-detail/withdraw/WithdrawInfoBar.jsx";
+import { EpochSecondToDateObject } from "@/utils/EpochConverter.js";
+import { PropTypes } from "prop-types";
 
 const Styled = {
   Container: styled.div``,
@@ -36,6 +38,25 @@ const Styled = {
   `,
 };
 
+const withdrawInfo1 = {
+  withdrawId: 1,
+  usage: "강남역 스크린도어",
+  withdrawAmount: 2_000_000,
+  balance: 5_000_000,
+  evidenceUrl:
+    "https://media.istockphoto.com/id/1285504723/ko/%EB%B2%A1%ED%84%B0/%ED%8C%90%EB%A7%A4-%EC%98%81%EC%88%98%EC%A6%9D.jpg?s=612x612&w=0&k=20&c=xf9rUJXZ-BqwZKqnlL8QCeCCXdjGsVqfU5ZVsUjpnRs=",
+  withdrawTime: 1699017340,
+};
+
+const withdrawInfo2 = {
+  withdrawalId: 2,
+  usage: "신사역 스크린도어",
+  withdrawAmount: 1_000_000,
+  balance: 2_000_000,
+  evidenceUrl: null,
+  withdrawTime: 1699017340,
+};
+
 function Withdraw({ isOrganizer }) {
   const leftMoney = 1000000;
   return (
@@ -44,7 +65,7 @@ function Withdraw({ isOrganizer }) {
         <Styled.Title>
           <div className="title">출금내역</div>
           <div className="description">
-            해당 내역을 클릭하면 자세한 사용 내역을 확인할 수 있어요
+            해당 내역을 클릭하면 자세한 사용 내역 이미지를 확인할 수 있어요
           </div>
         </Styled.Title>
         {isOrganizer && <Button>출금하기</Button>}
@@ -55,12 +76,26 @@ function Withdraw({ isOrganizer }) {
         <div className="left-money">{leftMoney.toLocaleString("ko-KR")}원</div>
       </Styled.TotalMoneyBar>
 
-      <WithdrawInfoBar />
-      {/*<WithdrawInfoBar />*/}
-      {/*<WithdrawInfoBar />*/}
-      {/*<WithdrawInfoBar />*/}
+      {[withdrawInfo1, withdrawInfo2, withdrawInfo1, withdrawInfo2].map(
+        (info, index) => (
+          <WithdrawInfoBar
+            key={index}
+            isOrganizer={isOrganizer}
+            id={info?.withdrawId}
+            date={EpochSecondToDateObject(info?.withdrawTime)}
+            usageTitle={info?.usage}
+            evidenceUrl={info?.evidenceUrl}
+            withdrawMoney={info?.withdrawAmount}
+            totalMoney={info?.balance}
+          />
+        ),
+      )}
     </Styled.Container>
   );
 }
+
+Withdraw.propTypes = {
+  isOrganizer: PropTypes.bool,
+};
 
 export default Withdraw;

--- a/src/src/components/fund-detail/withdraw/Withdraw.jsx
+++ b/src/src/components/fund-detail/withdraw/Withdraw.jsx
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import Button from "@/components/common/button/Button.jsx";
+import WithdrawInfoBar from "@/components/fund-detail/withdraw/WithdrawInfoBar.jsx";
 
 const Styled = {
   Container: styled.div``,
@@ -53,6 +54,11 @@ function Withdraw({ isOrganizer }) {
         <div className="description">남은 금액</div>
         <div className="left-money">{leftMoney.toLocaleString("ko-KR")}원</div>
       </Styled.TotalMoneyBar>
+
+      <WithdrawInfoBar />
+      {/*<WithdrawInfoBar />*/}
+      {/*<WithdrawInfoBar />*/}
+      {/*<WithdrawInfoBar />*/}
     </Styled.Container>
   );
 }

--- a/src/src/components/fund-detail/withdraw/Withdraw.jsx
+++ b/src/src/components/fund-detail/withdraw/Withdraw.jsx
@@ -1,5 +1,60 @@
-function Withdraw() {
-  return <div>출금하기</div>;
+import styled from "styled-components";
+import Button from "@/components/common/button/Button.jsx";
+
+const Styled = {
+  Container: styled.div``,
+  TitleBar: styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  `,
+  Title: styled.div`
+    padding-right: 0.5rem;
+    .title {
+      padding-bottom: 0.5rem;
+      font-size: 1.5rem;
+      font-weight: 600;
+    }
+
+    .description {
+      font-size: 0.75rem;
+    }
+  `,
+  TotalMoneyBar: styled.div`
+    padding: 1.5rem 0 1rem 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: ${({ theme }) => theme.border.strong};
+
+    font-size: 1.25rem;
+    font-weight: 600;
+    .left-money {
+      color: ${({ theme }) => theme.color.mainRed};
+    }
+  `,
+};
+
+function Withdraw({ isOrganizer }) {
+  const leftMoney = 1000000;
+  return (
+    <Styled.Container>
+      <Styled.TitleBar>
+        <Styled.Title>
+          <div className="title">출금내역</div>
+          <div className="description">
+            해당 내역을 클릭하면 자세한 사용 내역을 확인할 수 있어요
+          </div>
+        </Styled.Title>
+        {isOrganizer && <Button>출금하기</Button>}
+      </Styled.TitleBar>
+
+      <Styled.TotalMoneyBar>
+        <div className="description">남은 금액</div>
+        <div className="left-money">{leftMoney.toLocaleString("ko-KR")}원</div>
+      </Styled.TotalMoneyBar>
+    </Styled.Container>
+  );
 }
 
 export default Withdraw;

--- a/src/src/components/fund-detail/withdraw/Withdraw.jsx
+++ b/src/src/components/fund-detail/withdraw/Withdraw.jsx
@@ -1,8 +1,9 @@
 import styled from "styled-components";
-import Button from "@/components/common/button/Button.jsx";
-import WithdrawInfoBar from "@/components/fund-detail/withdraw/WithdrawInfoBar.jsx";
-import { EpochSecondToDateObject } from "@/utils/EpochConverter.js";
 import { PropTypes } from "prop-types";
+import { Suspense } from "react";
+import Button from "@/components/common/button/Button.jsx";
+import InfiniteWithdrawInfo from "@/components/fund-detail/withdraw/InfiniteWithdrawInfo.jsx";
+import InfiniteWithdrawInfoLoader from "@/components/fund-detail/withdraw/InfiniteWithdrawInfo.loader.jsx";
 
 const Styled = {
   Container: styled.div``,
@@ -23,42 +24,9 @@ const Styled = {
       font-size: 0.75rem;
     }
   `,
-  TotalMoneyBar: styled.div`
-    padding: 1.5rem 0 1rem 0;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    border-bottom: ${({ theme }) => theme.border.strong};
-
-    font-size: 1.25rem;
-    font-weight: 600;
-    .left-money {
-      color: ${({ theme }) => theme.color.mainRed};
-    }
-  `,
-};
-
-const withdrawInfo1 = {
-  withdrawId: 1,
-  usage: "강남역 스크린도어",
-  withdrawAmount: 2_000_000,
-  balance: 5_000_000,
-  evidenceUrl:
-    "https://media.istockphoto.com/id/1285504723/ko/%EB%B2%A1%ED%84%B0/%ED%8C%90%EB%A7%A4-%EC%98%81%EC%88%98%EC%A6%9D.jpg?s=612x612&w=0&k=20&c=xf9rUJXZ-BqwZKqnlL8QCeCCXdjGsVqfU5ZVsUjpnRs=",
-  withdrawTime: 1699017340,
-};
-
-const withdrawInfo2 = {
-  withdrawalId: 2,
-  usage: "신사역 스크린도어",
-  withdrawAmount: 1_000_000,
-  balance: 2_000_000,
-  evidenceUrl: null,
-  withdrawTime: 1699017340,
 };
 
 function Withdraw({ isOrganizer }) {
-  const leftMoney = 1000000;
   return (
     <Styled.Container>
       <Styled.TitleBar>
@@ -71,25 +39,9 @@ function Withdraw({ isOrganizer }) {
         {isOrganizer && <Button>출금하기</Button>}
       </Styled.TitleBar>
 
-      <Styled.TotalMoneyBar>
-        <div className="description">남은 금액</div>
-        <div className="left-money">{leftMoney.toLocaleString("ko-KR")}원</div>
-      </Styled.TotalMoneyBar>
-
-      {[withdrawInfo1, withdrawInfo2, withdrawInfo1, withdrawInfo2].map(
-        (info, index) => (
-          <WithdrawInfoBar
-            key={index}
-            isOrganizer={isOrganizer}
-            id={info?.withdrawId}
-            date={EpochSecondToDateObject(info?.withdrawTime)}
-            usageTitle={info?.usage}
-            evidenceUrl={info?.evidenceUrl}
-            withdrawMoney={info?.withdrawAmount}
-            totalMoney={info?.balance}
-          />
-        ),
-      )}
+      <Suspense fallback={<InfiniteWithdrawInfoLoader />}>
+        <InfiniteWithdrawInfo isOrganizer={isOrganizer} />
+      </Suspense>
     </Styled.Container>
   );
 }

--- a/src/src/components/fund-detail/withdraw/WithdrawInfoBar.jsx
+++ b/src/src/components/fund-detail/withdraw/WithdrawInfoBar.jsx
@@ -25,14 +25,19 @@ const Styled = {
     border: ${({ theme }) => theme.border.main};
     border-radius: 0.25rem;
     cursor: ${({ $pointer }) => $pointer && "pointer"};
+    overflow: clip;
   `,
   EvidenceWrapper: styled.div`
+    padding-right: 1rem;
     display: flex;
     justify-content: flex-start;
     align-items: center;
     .usage-title {
       padding-left: 0.5rem;
       font-weight: 600;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
   `,
   EvidenceImg: styled.img`
@@ -44,6 +49,10 @@ const Styled = {
     .withdraw-money {
       padding-bottom: 0.25rem;
       font-weight: 600;
+
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     .total-money {

--- a/src/src/components/fund-detail/withdraw/WithdrawInfoBar.jsx
+++ b/src/src/components/fund-detail/withdraw/WithdrawInfoBar.jsx
@@ -1,6 +1,9 @@
 import styled from "styled-components";
+import { useState } from "react";
 import formatDateToYYYYMMDD from "@/utils/formateDateToYYYYMMDD";
 import EvidenceIcon from "@/components/fund-detail/withdraw/EvidenceIcon.jsx";
+import EvidenceModal from "@/components/fund-detail/withdraw/EvidenceModal.jsx";
+import { PropTypes } from "prop-types";
 
 const Styled = {
   Container: styled.div`
@@ -21,7 +24,7 @@ const Styled = {
     background-color: ${({ theme }) => theme.color.white};
     border: ${({ theme }) => theme.border.main};
     border-radius: 0.25rem;
-    cursor: pointer;
+    cursor: ${({ $pointer }) => $pointer && "pointer"};
   `,
   EvidenceWrapper: styled.div`
     display: flex;
@@ -50,41 +53,80 @@ const Styled = {
     }
   `,
 };
-function WithdrawInfoBar() {
-  const date = new Date("2023-10-11");
-  const usageTitle = "사용한 곳";
-  // const evidenceUrl = "";
-  const evidenceUrl =
-    "https://media.istockphoto.com/id/1285504723/ko/%EB%B2%A1%ED%84%B0/%ED%8C%90%EB%A7%A4-%EC%98%81%EC%88%98%EC%A6%9D.jpg?s=612x612&w=0&k=20&c=xf9rUJXZ-BqwZKqnlL8QCeCCXdjGsVqfU5ZVsUjpnRs=";
-  const withdrawMoney = 100000;
-  const totalMoney = 500000;
+
+/**
+ * 출금 내역 컴포넌트
+ * @param {boolean} isOrganizer
+ * @param {number} id
+ * @param {Date} date
+ * @param {string} usageTitle
+ * @param {string=} evidenceUrl
+ * @param {number} withdrawMoney
+ * @param {number} totalMoney
+ */
+
+function WithdrawInfoBar({
+  isOrganizer,
+  id,
+  date,
+  usageTitle,
+  evidenceUrl,
+  withdrawMoney,
+  totalMoney,
+}) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   return (
-    <Styled.Container>
-      <Styled.Date>{formatDateToYYYYMMDD(date)}</Styled.Date>
-      <Styled.Bar>
-        <Styled.EvidenceWrapper>
-          {evidenceUrl ? (
-            <Styled.EvidenceImg
-              src={evidenceUrl}
-              alt={`${usageTitle} 증거 사진`}
-            />
-          ) : (
-            <EvidenceIcon />
-          )}
-          <div className="usage-title">{usageTitle}</div>
-        </Styled.EvidenceWrapper>
-        <Styled.MoneyWrapper>
-          <div className="withdraw-money">
-            -{withdrawMoney.toLocaleString("ko-KR")}원
-          </div>
-          <div className="total-money">
-            {totalMoney.toLocaleString("ko-KR")}원
-          </div>
-        </Styled.MoneyWrapper>
-      </Styled.Bar>
-    </Styled.Container>
+    <>
+      <Styled.Container
+        onClick={() => {
+          setIsModalOpen(true);
+        }}
+      >
+        <Styled.Date>{formatDateToYYYYMMDD(date)}</Styled.Date>
+        <Styled.Bar $pointer={evidenceUrl}>
+          <Styled.EvidenceWrapper>
+            {evidenceUrl ? (
+              <Styled.EvidenceImg
+                src={evidenceUrl}
+                alt={`${usageTitle} 증거 사진`}
+              />
+            ) : (
+              <EvidenceIcon />
+            )}
+            <div className="usage-title">{usageTitle}</div>
+          </Styled.EvidenceWrapper>
+          <Styled.MoneyWrapper>
+            <div className="withdraw-money">
+              -{withdrawMoney.toLocaleString("ko-KR")}원
+            </div>
+            <div className="total-money">
+              {totalMoney.toLocaleString("ko-KR")}원
+            </div>
+          </Styled.MoneyWrapper>
+        </Styled.Bar>
+      </Styled.Container>
+
+      {evidenceUrl && isModalOpen && (
+        <EvidenceModal
+          isOrganizer={isOrganizer}
+          title={usageTitle}
+          evidenceImgUrl={evidenceUrl}
+          setOpen={setIsModalOpen}
+        />
+      )}
+    </>
   );
 }
+
+WithdrawInfoBar.propTypes = {
+  isOrganizer: PropTypes.bool,
+  id: PropTypes.number,
+  date: PropTypes.date,
+  usageTitle: PropTypes.string,
+  evidenceUrl: PropTypes.string,
+  withdrawMoney: PropTypes.number,
+  totalMoney: PropTypes.number,
+};
 
 export default WithdrawInfoBar;

--- a/src/src/components/fund-detail/withdraw/WithdrawInfoBar.jsx
+++ b/src/src/components/fund-detail/withdraw/WithdrawInfoBar.jsx
@@ -93,7 +93,7 @@ function WithdrawInfoBar({
         }}
       >
         <Styled.Date>{formatDateToYYYYMMDD(date)}</Styled.Date>
-        <Styled.Bar $pointer={evidenceUrl}>
+        <Styled.Bar $pointer={evidenceUrl || isOrganizer}>
           <Styled.EvidenceWrapper>
             {evidenceUrl ? (
               <Styled.EvidenceImg
@@ -116,8 +116,9 @@ function WithdrawInfoBar({
         </Styled.Bar>
       </Styled.Container>
 
-      {evidenceUrl && isModalOpen && (
+      {(evidenceUrl || isOrganizer) && isModalOpen && (
         <EvidenceModal
+          withdrawId={id}
           isOrganizer={isOrganizer}
           title={usageTitle}
           evidenceImgUrl={evidenceUrl}

--- a/src/src/components/fund-detail/withdraw/WithdrawInfoBar.jsx
+++ b/src/src/components/fund-detail/withdraw/WithdrawInfoBar.jsx
@@ -122,7 +122,7 @@ function WithdrawInfoBar({
 WithdrawInfoBar.propTypes = {
   isOrganizer: PropTypes.bool,
   id: PropTypes.number,
-  date: PropTypes.date,
+  date: PropTypes.any,
   usageTitle: PropTypes.string,
   evidenceUrl: PropTypes.string,
   withdrawMoney: PropTypes.number,

--- a/src/src/components/fund-detail/withdraw/WithdrawInfoBar.jsx
+++ b/src/src/components/fund-detail/withdraw/WithdrawInfoBar.jsx
@@ -1,0 +1,90 @@
+import styled from "styled-components";
+import formatDateToYYYYMMDD from "@/utils/formateDateToYYYYMMDD";
+import EvidenceIcon from "@/components/fund-detail/withdraw/EvidenceIcon.jsx";
+
+const Styled = {
+  Container: styled.div`
+    margin: 1rem 0;
+    width: 100%;
+  `,
+  Date: styled.div`
+    padding-bottom: 0.25rem;
+    font-size: 0.75rem;
+    color: ${({ theme }) => theme.color.addition};
+  `,
+  Bar: styled.div`
+    padding: 1rem;
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background-color: ${({ theme }) => theme.color.white};
+    border: ${({ theme }) => theme.border.main};
+    border-radius: 0.25rem;
+    cursor: pointer;
+  `,
+  EvidenceWrapper: styled.div`
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    .usage-title {
+      padding-left: 0.5rem;
+      font-weight: 600;
+    }
+  `,
+  EvidenceImg: styled.img`
+    width: 2rem;
+    height: 2rem;
+    border-radius: 9999px;
+  `,
+  MoneyWrapper: styled.div`
+    .withdraw-money {
+      padding-bottom: 0.25rem;
+      font-weight: 600;
+    }
+
+    .total-money {
+      text-align: right;
+      font-size: 0.75rem;
+      color: ${({ theme }) => theme.color.inactive};
+    }
+  `,
+};
+function WithdrawInfoBar() {
+  const date = new Date("2023-10-11");
+  const usageTitle = "사용한 곳";
+  // const evidenceUrl = "";
+  const evidenceUrl =
+    "https://media.istockphoto.com/id/1285504723/ko/%EB%B2%A1%ED%84%B0/%ED%8C%90%EB%A7%A4-%EC%98%81%EC%88%98%EC%A6%9D.jpg?s=612x612&w=0&k=20&c=xf9rUJXZ-BqwZKqnlL8QCeCCXdjGsVqfU5ZVsUjpnRs=";
+  const withdrawMoney = 100000;
+  const totalMoney = 500000;
+
+  return (
+    <Styled.Container>
+      <Styled.Date>{formatDateToYYYYMMDD(date)}</Styled.Date>
+      <Styled.Bar>
+        <Styled.EvidenceWrapper>
+          {evidenceUrl ? (
+            <Styled.EvidenceImg
+              src={evidenceUrl}
+              alt={`${usageTitle} 증거 사진`}
+            />
+          ) : (
+            <EvidenceIcon />
+          )}
+          <div className="usage-title">{usageTitle}</div>
+        </Styled.EvidenceWrapper>
+        <Styled.MoneyWrapper>
+          <div className="withdraw-money">
+            -{withdrawMoney.toLocaleString("ko-KR")}원
+          </div>
+          <div className="total-money">
+            {totalMoney.toLocaleString("ko-KR")}원
+          </div>
+        </Styled.MoneyWrapper>
+      </Styled.Bar>
+    </Styled.Container>
+  );
+}
+
+export default WithdrawInfoBar;

--- a/src/src/components/fund-detail/withdraw/WithdrawInfoBar.skeleton.jsx
+++ b/src/src/components/fund-detail/withdraw/WithdrawInfoBar.skeleton.jsx
@@ -1,0 +1,101 @@
+import styled from "styled-components";
+import { Shimmer } from "@/styles/CommonStyle";
+
+const Styled = {
+  Container: styled.div`
+    margin: 1rem 0;
+    width: 100%;
+  `,
+  Date: styled.div`
+    width: 3rem;
+    margin-bottom: 0.25rem;
+    height: 0.75rem;
+    background-color: ${({ theme }) => theme.color.skeleton};
+    overflow: hidden;
+    border-radius: 0.25rem;
+  `,
+  Bar: styled.div`
+    padding: 1rem;
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background-color: ${({ theme }) => theme.color.white};
+    border: ${({ theme }) => theme.border.main};
+    border-radius: 0.25rem;
+  `,
+  EvidenceWrapper: styled.div`
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    .icon {
+      width: 2rem;
+      height: 2rem;
+      border-radius: 9999px;
+      background-color: ${({ theme }) => theme.color.skeleton};
+      overflow: hidden;
+    }
+    .usage-title {
+      width: 5rem;
+      margin-left: 0.5rem;
+      font-weight: 600;
+      height: 1rem;
+      background-color: ${({ theme }) => theme.color.skeleton};
+      overflow: hidden;
+      border-radius: 0.25rem;
+    }
+  `,
+  MoneyWrapper: styled.div`
+    .withdraw-money {
+      width: 5rem;
+      margin-bottom: 0.25rem;
+      font-weight: 600;
+      height: 1rem;
+      background-color: ${({ theme }) => theme.color.skeleton};
+      overflow: hidden;
+      border-radius: 0.25rem;
+    }
+
+    .total-money {
+      width: 3rem;
+      float: right;
+      height: 0.75rem;
+      background-color: ${({ theme }) => theme.color.skeleton};
+      overflow: hidden;
+      border-radius: 0.25rem;
+    }
+  `,
+};
+
+function WithdrawInfoBarSkeleton() {
+  return (
+    <>
+      <Styled.Container>
+        <Styled.Date>
+          <Shimmer />
+        </Styled.Date>
+        <Styled.Bar>
+          <Styled.EvidenceWrapper>
+            <div className="icon">
+              <Shimmer />
+            </div>
+
+            <div className="usage-title">
+              <Shimmer />
+            </div>
+          </Styled.EvidenceWrapper>
+          <Styled.MoneyWrapper>
+            <div className="withdraw-money">
+              <Shimmer />
+            </div>
+            <div className="total-money">
+              <Shimmer />
+            </div>
+          </Styled.MoneyWrapper>
+        </Styled.Bar>
+      </Styled.Container>
+    </>
+  );
+}
+
+export default WithdrawInfoBarSkeleton;

--- a/src/src/components/fund-detail/withdraw/index.jsx
+++ b/src/src/components/fund-detail/withdraw/index.jsx
@@ -1,5 +1,0 @@
-function Index() {
-  return <div>출금하기</div>;
-}
-
-export default Index;

--- a/src/src/constants/API.js
+++ b/src/src/constants/API.js
@@ -19,6 +19,9 @@ const FUND = {
   WITHDRAW: (fundId) => {
     return `/posts/${fundId}/withdrawals`;
   },
+  WITHDRAW_IMAGE: ({ fundId, withdrawId }) => {
+    return `/posts/${fundId}/withdrawals/${withdrawId}`;
+  },
 };
 
 const USER = {

--- a/src/src/constants/API.js
+++ b/src/src/constants/API.js
@@ -16,6 +16,9 @@ const FUND = {
   DETAIL: (fundId) => {
     return `/posts/${fundId}`;
   },
+  WITHDRAW: (fundId) => {
+    return `/posts/${fundId}/withdrawals`;
+  },
 };
 
 const USER = {

--- a/src/src/constants/routes.js
+++ b/src/src/constants/routes.js
@@ -2,16 +2,17 @@ const routes = {
   home: "/",
   fund: "/fund",
   createFund: "/create-fund",
+  support: "/support",
+  mobilePayment: "/mobile-payment",
+  withdraw: "/withdraw",
   celebrity: "/celebrity",
+  user: "/user",
   myFund: "/my-fund",
   myAccount: "/my-account",
   signIn: "/sign-in",
   signUp: "/sign-up",
-  user: "/user",
   edit: "/edit",
   admin: "/admin",
-  support: "/support",
-  mobilePayment: "/mobile-payment",
 };
 
 Object.freeze(routes);

--- a/src/src/hooks/api/fund/useFundWithdrawEvidenceImageMutation.js
+++ b/src/src/hooks/api/fund/useFundWithdrawEvidenceImageMutation.js
@@ -1,0 +1,28 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import API from "@/constants/API.js";
+import FundAPI from "@/api/fundAPI.js";
+
+function useFundWithdrawEvidenceImageMutation({ fundId, withdrawId }) {
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    [API.FUND.WITHDRAW_IMAGE({ fundId, withdrawId })],
+    async ({ image }) => {
+      const imageForm = new FormData();
+      imageForm.append("image", image);
+
+      await FundAPI.postFundWithdrawEvidenceImage({
+        fundId,
+        withdrawId,
+        imageForm,
+      });
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(API.FUND.WITHDRAW(fundId));
+      },
+    },
+  );
+}
+
+export default useFundWithdrawEvidenceImageMutation;

--- a/src/src/hooks/api/fund/useInfiniteWithdrawInfoQuery.js
+++ b/src/src/hooks/api/fund/useInfiniteWithdrawInfoQuery.js
@@ -1,0 +1,20 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import API from "@/constants/API.js";
+import fundAPI from "@/api/fundAPI.js";
+
+function useInfiniteWithdrawInfoQuery({ fundId }) {
+  return useInfiniteQuery(
+    [API.FUND.WITHDRAW(fundId)],
+    async ({ pageParam = 0 }) => {
+      return fundAPI.getFundWithdrawInfo({ fundId, pageIndex: pageParam });
+    },
+    {
+      suspense: true,
+      getNextPageParam: (lastPage) => {
+        return lastPage.config.params.pageIndex + 1;
+      },
+    },
+  );
+}
+
+export default useInfiniteWithdrawInfoQuery;

--- a/src/src/main.jsx
+++ b/src/src/main.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "@/App.jsx";
 
-if (import.meta.env.DEV) {
+if (import.meta.env.VITE_USE_MOCK_API) {
   const { worker } = await import("./mocks/browser.js");
   worker.start();
 }

--- a/src/src/mocks/handler/fundHandlers.js
+++ b/src/src/mocks/handler/fundHandlers.js
@@ -87,6 +87,25 @@ const sonnyFundDetailInfo2 = {
   isOrganizer: false,
 };
 
+const withdrawInfo1 = {
+  withdrawId: 1,
+  usage: "강남역 스크린도어",
+  withdrawAmount: 2_000_000,
+  balance: 5_000_000,
+  evidenceUrl:
+    "https://media.istockphoto.com/id/1285504723/ko/%EB%B2%A1%ED%84%B0/%ED%8C%90%EB%A7%A4-%EC%98%81%EC%88%98%EC%A6%9D.jpg?s=612x612&w=0&k=20&c=xf9rUJXZ-BqwZKqnlL8QCeCCXdjGsVqfU5ZVsUjpnRs=",
+  withdrawTime: 1699017340,
+};
+
+const withdrawInfo2 = {
+  withdrawalId: 2,
+  usage: "신사역 스크린도어",
+  withdrawAmount: 1_000_000,
+  balance: 2_000_000,
+  evidenceUrl: null,
+  withdrawTime: 1699017340,
+};
+
 export const fundHandlers = [
   // 펀딩 목록 조회
   rest.get("/api" + API.FUND.LIST, (req, res, ctx) => {
@@ -211,5 +230,31 @@ export const fundHandlers = [
     }
 
     return res(ctx.status(200), ctx.json({ introduction: intro }));
+  }),
+
+  // 펀딩 출금내역 조회
+  rest.get("/api" + API.FUND.WITHDRAW(":fundId"), (req, res, ctx) => {
+    const { fundId } = req.params;
+
+    if (!fundId) {
+      return res(
+        ctx.status(400),
+        ctx.json({ message: "존재하지 않는 펀딩입니다" }),
+      );
+    }
+
+    return res(
+      ctx.status(200),
+      ctx.json({
+        currentBalance: 5000000,
+        withdrawalDTOs: [
+          withdrawInfo1,
+          withdrawInfo2,
+          withdrawInfo1,
+          withdrawInfo2,
+        ],
+        isLastPage: false,
+      }),
+    );
   }),
 ];

--- a/src/src/mocks/handler/fundHandlers.js
+++ b/src/src/mocks/handler/fundHandlers.js
@@ -257,4 +257,19 @@ export const fundHandlers = [
       }),
     );
   }),
+
+  // 펀딩 출금내역 이미지 추가
+  rest.post(
+    "/api" +
+      API.FUND.WITHDRAW_IMAGE({ fundId: ":fundId", withdrawId: ":withdrawId" }),
+    (req, res, ctx) => {
+      const { fundId, withdrawId } = req.params;
+
+      if (!fundId || !withdrawId) {
+        return res(ctx.status(400));
+      }
+
+      return res(ctx.status(200));
+    },
+  ),
 ];

--- a/src/src/pages/FundDetail.page.jsx
+++ b/src/src/pages/FundDetail.page.jsx
@@ -42,6 +42,8 @@ const Styled = {
 
 function FundDetailPage() {
   const [selectedTab, setSelectedTab] = useState(TABS.FUND_DETAIL.INTRO);
+  // TODO: isOrganizer api 통신 결과로 변경: 현재는 css 작업을 위해 true로 함
+  // const [isOrganizer, setIsOrganizer] = useState(false)
 
   const tabInfoArray = Object.keys(TABS.FUND_DETAIL).map((key) => {
     return {

--- a/src/src/pages/FundDetail.page.jsx
+++ b/src/src/pages/FundDetail.page.jsx
@@ -42,8 +42,7 @@ const Styled = {
 
 function FundDetailPage() {
   const [selectedTab, setSelectedTab] = useState(TABS.FUND_DETAIL.INTRO);
-  // TODO: isOrganizer api 통신 결과로 변경: 현재는 css 작업을 위해 true로 함
-  // const [isOrganizer, setIsOrganizer] = useState(false)
+  const [isOrganizer, setIsOrganizer] = useState(false);
 
   const tabInfoArray = Object.keys(TABS.FUND_DETAIL).map((key) => {
     return {
@@ -54,12 +53,10 @@ function FundDetailPage() {
     };
   });
 
-  const isOrganizer = true;
-
   return (
     <Styled.Container>
       <Suspense fallback={<InformationSkeleton />}>
-        <Information />
+        <Information setIsOrganizer={setIsOrganizer} />
       </Suspense>
       <Styled.DetailWrap>
         <Tabs tabInfoArray={tabInfoArray} style={{ paddingBottom: "1rem" }} />

--- a/src/src/router.jsx
+++ b/src/src/router.jsx
@@ -35,6 +35,10 @@ const privateChildren = [
     element: <FundTextEditPage />,
   },
   {
+    path: `${routes.withdraw}/:fundId`,
+    element: <div>출금하기</div>,
+  },
+  {
     // 모바일 결제 진행
     path: routes.mobilePayment,
     element: <MobilePaymentPage />,

--- a/src/src/utils/EpochConverter.js
+++ b/src/src/utils/EpochConverter.js
@@ -1,0 +1,7 @@
+export function EpochSecondToDateObject(epochSecond) {
+  return new Date(epochSecond * 1000);
+}
+
+export function DateObjectToEpochSecond(dateObject) {
+  return dateObject.getTime() / 1000.0;
+}

--- a/src/yarn.lock
+++ b/src/yarn.lock
@@ -1418,9 +1418,9 @@
   integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
 
 "@types/debug@^4.1.7":
-  version "4.1.9"
-  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.9.tgz#906996938bc672aaf2fb8c0d3733ae1dda05b005"
-  integrity sha512-8Hz50m2eoS56ldRlepxSBa6PWEVCtzUo/92HgLc2qTMnotJNIm7xP+UZhyWoYsyOdd5dxZ+NZLb24rsKyFs2ow==
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.11.tgz#b20d24098288f19e48fdf776c5d9ccd024629e4e"
+  integrity sha512-R2qflTjHDs4CL6D/6TkqBeIHr54WzZfIxN729xvCNlYIVp2LknlnCro5Yo3frNaX2E5gO9pZ3/QAPVdGmu+q9w==
   dependencies:
     "@types/ms" "*"
 
@@ -1448,16 +1448,16 @@
   integrity sha512-T5k6kTXak79gwmIOaDF2UUQXFbnBE0zBUzF20pz7wDYu0RQMzWg+Ml/Pz50214NsFHBITkoi5VtdjFZnJ2ijjA==
 
 "@types/ms@*":
-  version "0.7.32"
-  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.32.tgz#f6cd08939ae3ad886fcc92ef7f0109dacddf61ab"
-  integrity sha512-xPSg0jm4mqgEkNhowKgZFBNtwoEwF6gJ4Dhww+GFpm3IgtNseHQZ5IqdNwnquZEoANxyDAKDRAdVo4Z72VvD/g==
+  version "0.7.33"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.33.tgz#80bf1da64b15f21fd8c1dc387c31929317d99ee9"
+  integrity sha512-AuHIyzR5Hea7ij0P9q7vx7xu4z0C28ucwjAZC0ja7JhINyCnOw8/DnvAPQQ9TfOlCtZAmCERKQX9+o1mgQhuOQ==
 
 "@types/node@*":
-  version "20.8.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.8.5.tgz#13352ae1f80032171616910e8aba2e3e52e57d96"
-  integrity sha512-SPlobFgbidfIeOYlzXiEjSYeIJiOCthv+9tSQVpvk4PAdIIc+2SmjNVzWXk9t0Y7dl73Zdf+OgXKHX9XtkqUpw==
+  version "20.8.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.8.10.tgz#a5448b895c753ae929c26ce85cab557c6d4a365e"
+  integrity sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==
   dependencies:
-    undici-types "~5.25.1"
+    undici-types "~5.26.4"
 
 "@types/prop-types@*":
   version "15.7.7"
@@ -1493,9 +1493,9 @@
   integrity sha512-2L9ifAGl7wmXwP4v3pN4p2FLhD0O1qsJpvKmNin5VA8+UvNVb447UDaAEV6UdrkA+m/Xs58U1RFps44x6TFsVQ==
 
 "@types/set-cookie-parser@^2.4.0":
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/@types/set-cookie-parser/-/set-cookie-parser-2.4.4.tgz#3c36c9147960cca0fc7c508aacb18ea41f6b5003"
-  integrity sha512-xCfTC/eL/GmvMC24b42qJpYSTdCIBwWcfskDF80ztXtnU6pKXyvuZP2EConb2K9ps0s7gMhCa0P1foy7wiItMA==
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/@types/set-cookie-parser/-/set-cookie-parser-2.4.5.tgz#f08fc44f9ab0bb136b7a73bc4e73de7c0c747cf3"
+  integrity sha512-ZPmztaAQ4rbnW/WTUnT1dwSENQo4bjGqxCSeyK+gZxmd+zJl/QAeF6dpEXcS5UEJX22HwiggFSaY8nE1nRmkbg==
   dependencies:
     "@types/node" "*"
 
@@ -1791,6 +1791,15 @@ call-bind@^1.0.0, call-bind@^1.0.2:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.2"
 
+call-bind@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.5.tgz#6fa2b7845ce0ea49bf4d8b9ef64727a2c2e2e513"
+  integrity sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==
+  dependencies:
+    function-bind "^1.1.2"
+    get-intrinsic "^1.2.1"
+    set-function-length "^1.1.1"
+
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
@@ -2037,6 +2046,15 @@ define-data-property@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.0.tgz#0db13540704e1d8d479a0656cf781267531b9451"
   integrity sha512-UzGwzcjyv3OtAvolTj1GoyNYzfFR+iqbGjcnBEENZVCpM4/Ng1yhGNvS3lR/xDS74Tb2wGG9WzNSNIOS9UVb2g==
+  dependencies:
+    get-intrinsic "^1.2.1"
+    gopd "^1.0.1"
+    has-property-descriptors "^1.0.0"
+
+define-data-property@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.1.tgz#c35f7cd0ab09883480d12ac5cb213715587800b3"
+  integrity sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==
   dependencies:
     get-intrinsic "^1.2.1"
     gopd "^1.0.1"
@@ -2573,6 +2591,11 @@ function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+
+function-bind@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
+  integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
 function.prototype.name@^1.1.5, function.prototype.name@^1.1.6:
   version "1.1.6"
@@ -4108,6 +4131,16 @@ set-cookie-parser@^2.4.6:
   resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz#131921e50f62ff1a66a461d7d62d7b21d5d15a51"
   integrity sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==
 
+set-function-length@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.1.1.tgz#4bc39fafb0307224a33e106a7d35ca1218d659ed"
+  integrity sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==
+  dependencies:
+    define-data-property "^1.1.1"
+    get-intrinsic "^1.2.1"
+    gopd "^1.0.1"
+    has-property-descriptors "^1.0.0"
+
 set-function-name@^2.0.0, set-function-name@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/set-function-name/-/set-function-name-2.0.1.tgz#12ce38b7954310b9f61faa12701620a0c882793a"
@@ -4464,10 +4497,10 @@ underscore@~1.13.2:
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
   integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
 
-undici-types@~5.25.1:
-  version "5.25.3"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.25.3.tgz#e044115914c85f0bcbb229f346ab739f064998c3"
-  integrity sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"
@@ -4641,13 +4674,24 @@ which-collection@^1.0.1:
     is-weakmap "^2.0.1"
     is-weakset "^2.0.1"
 
-which-typed-array@^1.1.11, which-typed-array@^1.1.2, which-typed-array@^1.1.9:
+which-typed-array@^1.1.11, which-typed-array@^1.1.9:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.11.tgz#99d691f23c72aab6768680805a271b69761ed61a"
   integrity sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==
   dependencies:
     available-typed-arrays "^1.0.5"
     call-bind "^1.0.2"
+    for-each "^0.3.3"
+    gopd "^1.0.1"
+    has-tostringtag "^1.0.0"
+
+which-typed-array@^1.1.2:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.13.tgz#870cd5be06ddb616f504e7b039c4c24898184d36"
+  integrity sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.4"
     for-each "^0.3.3"
     gopd "^1.0.1"
     has-tostringtag "^1.0.0"


### PR DESCRIPTION
## 주요 사항
- 펀딩 상세 페이지 출금 내역의 UI 및 mock api 작업


<img width="562" alt="image" src="https://github.com/Step3-kakao-tech-campus/Team13_FE/assets/75734220/3cb17359-d28f-441c-9b48-b1fd6ae36e75">

- 출금 증빙 사진 formData api로 post하는 로직 추가했습니다! msw에서 formData에 접근하려면 라이브러리 버전을 마이그레이션 해야하는데 그러면 바뀌는 게 너무 많아서 바꾸진 않았습니다! 다른 분들 formData 관련 작업할 때 mock api에서 추가적으로 확인은 못하고 대신 개발자 도구에서 formData가 적절히 가는지만 확인해주세요 @sihyonn @Klomachenko 



## 스크린샷
### pc
<img width="822" alt="image" src="https://github.com/Step3-kakao-tech-campus/Team13_FE/assets/75734220/4945df54-9894-46da-87d0-9fec52135750">

### mobile
<img width="822" alt="image" src="https://github.com/Step3-kakao-tech-campus/Team13_FE/assets/75734220/e72c3c8a-b6d2-40d0-962f-dbf28439c845">


### 주최자인 경우 모달창
<img width="822" alt="image" src="https://github.com/Step3-kakao-tech-campus/Team13_FE/assets/75734220/03828406-705f-4013-b9c5-e6d46d54987f">
<img width="822" alt="image" src="https://github.com/Step3-kakao-tech-campus/Team13_FE/assets/75734220/47315e80-e952-459b-9d48-17487c2ed4f7">
<img width="822" alt="image" src="https://github.com/Step3-kakao-tech-campus/Team13_FE/assets/75734220/20c7e65e-79f5-4162-9051-7ea0282052fc">

### 주최자 아니고 이미지가 있는 경우 모달창
<img width="822" alt="image" src="https://github.com/Step3-kakao-tech-campus/Team13_FE/assets/75734220/4e43185b-8efc-4b87-87e0-0cb5d9439501">

### 관련 이슈
close #115 
