### PR TITLE
셀럽상세페이지 - 셀럽상세정보(상단), 셀럽관련펀딩목록(하단) mock api 작업

### DIFF
--- a/src/src/api/celebrityAPI.js
+++ b/src/src/api/celebrityAPI.js
@@ -1,5 +1,6 @@
 import instance from "@/api/instance.js";
 import API from "@/constants/API.js";
+import { CelebDetailInfoDto } from "./dto/celebrity.dto.js";
 
 /**
  * 셀럽 목록 조회 api
@@ -55,9 +56,22 @@ const postCelebApply = async ({
   });
 };
 
+/**
+ * 셀럽 상세정보 조회 api
+ */
+const getCelebDetailInfo = async (celebId) => {
+  const { data } = await instance({
+    url: API.CELEBRITY.DETAIL(celebId),
+    method: "GET",
+  });
+
+  return new CelebDetailInfoDto(data);
+};
+
 export default {
   getCelebInfoList,
   postCelebFollow,
   postCelebUnfollow,
   postCelebApply,
+  getCelebDetailInfo,
 };

--- a/src/src/api/celebrityAPI.js
+++ b/src/src/api/celebrityAPI.js
@@ -68,10 +68,32 @@ const getCelebDetailInfo = async (celebId) => {
   return new CelebDetailInfoDto(data);
 };
 
+/**
+ * 셀럽관련 펀딩목록 조회 api
+ */
+const getCelebRelatedFund = async ({
+  celebId,
+  pageIndex,
+  keyword,
+  sortType,
+}) => {
+  return await instance({
+    url: API.CELEBRITY.FUNDING(celebId),
+    method: "GET",
+    params: {
+      celebId: celebId,
+      pageIndex: pageIndex,
+      keyword: keyword,
+      sortType: sortType,
+    },
+  });
+};
+
 export default {
   getCelebInfoList,
   postCelebFollow,
   postCelebUnfollow,
   postCelebApply,
   getCelebDetailInfo,
+  getCelebRelatedFund,
 };

--- a/src/src/api/celebrityAPI.js
+++ b/src/src/api/celebrityAPI.js
@@ -60,13 +60,11 @@ const postCelebApply = async ({
  * 셀럽 상세정보 조회 api
  */
 const getCelebDetailInfo = async (celebId) => {
-  console.log("이게나와야해", celebId);
   const { data } = await instance({
     url: API.CELEBRITY.DETAIL(celebId),
     method: "GET",
   });
 
-  console.log("셀럽데이터", data);
   return new CelebDetailInfoDto(data);
 };
 

--- a/src/src/api/celebrityAPI.js
+++ b/src/src/api/celebrityAPI.js
@@ -71,19 +71,13 @@ const getCelebDetailInfo = async (celebId) => {
 /**
  * 셀럽관련 펀딩목록 조회 api
  */
-const getCelebRelatedFund = async ({
-  celebId,
-  pageIndex,
-  keyword,
-  sortType,
-}) => {
+const getCelebRelatedFund = async ({ celebId, pageIndex, sortType }) => {
   return await instance({
     url: API.CELEBRITY.FUNDING(celebId),
     method: "GET",
     params: {
       celebId: celebId,
       pageIndex: pageIndex,
-      keyword: keyword,
       sortType: sortType,
     },
   });

--- a/src/src/api/celebrityAPI.js
+++ b/src/src/api/celebrityAPI.js
@@ -1,6 +1,6 @@
 import instance from "@/api/instance.js";
 import API from "@/constants/API.js";
-import { CelebDetailInfoDto } from "./dto/celebrity.dto.js";
+import { CelebDetailInfoDto } from "@/api/dto/celebrity.dto.js";
 
 /**
  * 셀럽 목록 조회 api
@@ -60,11 +60,13 @@ const postCelebApply = async ({
  * 셀럽 상세정보 조회 api
  */
 const getCelebDetailInfo = async (celebId) => {
+  console.log("이게나와야해", celebId);
   const { data } = await instance({
     url: API.CELEBRITY.DETAIL(celebId),
     method: "GET",
   });
 
+  console.log("셀럽데이터", data);
   return new CelebDetailInfoDto(data);
 };
 

--- a/src/src/api/dto/celebrity.dto.js
+++ b/src/src/api/dto/celebrity.dto.js
@@ -20,4 +20,35 @@ class CelebInfoDto {
   }
 }
 
-export { CelebInfoDto };
+class CelebDetailInfoDto {
+  constructor({
+    celebId,
+    celebName,
+    celebGroup,
+    celebGender,
+    celebCategory,
+    profileUrl,
+    fundInProgressNum,
+    totalFundMoney,
+    followerNum,
+    isFollowing,
+    rank: { follower, fundMoney },
+  }) {
+    this.celebId = celebId;
+    this.celebName = celebName;
+    this.celebGroup = celebGroup;
+    this.celebGender = celebGender;
+    this.celebCategory = celebCategory;
+    this.profileUrl = profileUrl;
+    this.fundInProgressNum = fundInProgressNum;
+    this.totalFundMoney = totalFundMoney;
+    this.followerNum = followerNum;
+    this.isFollowing = isFollowing;
+    this.rank = {
+      follower,
+      fundMoney,
+    };
+  }
+}
+
+export { CelebInfoDto, CelebDetailInfoDto };

--- a/src/src/api/dto/celebrity.dto.js
+++ b/src/src/api/dto/celebrity.dto.js
@@ -51,4 +51,36 @@ class CelebDetailInfoDto {
   }
 }
 
-export { CelebInfoDto, CelebDetailInfoDto };
+class CelebRelatedFundDto {
+  constructor({
+    celebId,
+    fundId,
+    fundTitle,
+    thumbnailUrl,
+    targetDate,
+    targetMoney,
+    currentMoney,
+    celebrityId,
+    celebrityName,
+    celebrityProfileUrl,
+    organizerId,
+    organizerName,
+    isInUserWishList,
+  }) {
+    this.celebId = celebId;
+    this.fundId = fundId;
+    this.fundTitle = fundTitle;
+    this.thumbnailUrl = thumbnailUrl;
+    this.targetDate = targetDate;
+    this.targetMoney = targetMoney;
+    this.currentMoney = currentMoney;
+    this.celebrityId = celebrityId;
+    this.celebrityName = celebrityName;
+    this.celebrityProfileUrl = celebrityProfileUrl;
+    this.organizerId = organizerId;
+    this.organizerName = organizerName;
+    this.isInUserWishList = isInUserWishList;
+  }
+}
+
+export { CelebInfoDto, CelebDetailInfoDto, CelebRelatedFundDto };

--- a/src/src/api/fundAPI.js
+++ b/src/src/api/fundAPI.js
@@ -50,11 +50,12 @@ const deleteFundLike = async (fundId) => {
 };
 
 const getDetailInfoByFundId = async (fundId) => {
+  console.log("펀드 id", fundId);
   const { data } = await instance({
     url: API.FUND.DETAIL(fundId),
     method: "GET",
   });
-
+  console.log("펀딩데이터", data);
   return new FundDetailInfoDto(data);
 };
 

--- a/src/src/api/fundAPI.js
+++ b/src/src/api/fundAPI.js
@@ -50,12 +50,10 @@ const deleteFundLike = async (fundId) => {
 };
 
 const getDetailInfoByFundId = async (fundId) => {
-  console.log("펀드 id", fundId);
   const { data } = await instance({
     url: API.FUND.DETAIL(fundId),
     method: "GET",
   });
-  console.log("펀딩데이터", data);
   return new FundDetailInfoDto(data);
 };
 

--- a/src/src/components/celebrity-detail/CelebDetailInfo.jsx
+++ b/src/src/components/celebrity-detail/CelebDetailInfo.jsx
@@ -34,6 +34,11 @@ const Styled = {
   `,
 };
 
+/**
+ * 셀럽 상세정보 컴포넌트
+ * : 셀럽상세 페이지 상단 프로필, 팔로워/펀딩금액별 순위, 자세한텍스트정보
+ */
+
 function CelebDetailInfo() {
   const { celebId } = useParams();
   const { data } = useCelebDetailInfoQuery({ celebId: celebId });

--- a/src/src/components/celebrity-detail/CelebDetailInfo.jsx
+++ b/src/src/components/celebrity-detail/CelebDetailInfo.jsx
@@ -1,0 +1,74 @@
+import { useParams } from "react-router-dom";
+import styled from "styled-components";
+
+import useCelebDetailInfoQuery from "@/hooks/api/celebrity/useCelebDetailInfoQuery.js";
+
+import CelebProfile from "@/components/celebrity-detail/CelebProfile.jsx";
+import CelebRank from "@/components/celebrity-detail/CelebRank.jsx";
+import CelebTextInfo from "@/components/celebrity-detail/CelebTextInfo.jsx";
+
+const Styled = {
+  CelebInfoContainer: styled.div`
+    padding: 2rem calc((100% - 60rem) / 2);
+  `,
+
+  CelebInfoBottomBox: styled.div`
+    padding-top: 1rem;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 2rem;
+  `,
+
+  ProfileImage: styled.img`
+    width: 10rem;
+    height: 10rem;
+    object-fit: cover;
+    border-radius: 0.25rem;
+  `,
+
+  TextInfoContainer: styled.div`
+    display: flex;
+    flex-direction: column;
+  `,
+};
+
+function CelebDetailInfo() {
+  const { celebId } = useParams();
+  const { data } = useCelebDetailInfoQuery({ celebId: celebId });
+
+  return (
+    <Styled.CelebInfoContainer>
+      <CelebProfile
+        celebName={data?.celebName}
+        celebGroup={data?.celebGroup}
+        celebCategory={data?.celebCategory}
+        celebGender={data?.celebGender}
+        celebId={data?.celebId}
+        isFollowing={data?.isFollowing}
+      />
+
+      <Styled.CelebInfoBottomBox>
+        <Styled.ProfileImage
+          src={data?.profileUrl}
+          alt={`${data?.celebName}의 프로필 사진`}
+        />
+
+        <CelebRank
+          followerRank={data?.rank.follower}
+          fundingRank={data?.rank.fundMoney}
+        />
+
+        <CelebTextInfo
+          fundInProgressNum={data?.fundInProgressNum}
+          followerNum={data?.followerNum}
+          isFollowing={data?.isFollowing}
+          totalFundMoney={data?.totalFundMoney}
+        />
+      </Styled.CelebInfoBottomBox>
+    </Styled.CelebInfoContainer>
+  );
+}
+
+export default CelebDetailInfo;

--- a/src/src/components/celebrity-detail/CelebDetailInfoSkeleton.jsx
+++ b/src/src/components/celebrity-detail/CelebDetailInfoSkeleton.jsx
@@ -1,0 +1,5 @@
+function CelebDetailInfoSkeleton() {
+  return <div>셀럽 상세 스켈레톤</div>;
+}
+
+export default CelebDetailInfoSkeleton;

--- a/src/src/components/celebrity-detail/CelebDetailInfoSkeleton.jsx
+++ b/src/src/components/celebrity-detail/CelebDetailInfoSkeleton.jsx
@@ -1,5 +1,55 @@
+import styled from "styled-components";
+
+import CelebProfileSkeleton from "./skeleton/CelebProfileSkeleton.jsx";
+import CelebRankSkeleton from "./skeleton/CelebRankSkeleton.jsx";
+import CelebTextInfoSkeleton from "./skeleton/CelebTextInfoSkeleton.jsx";
+import { Shimmer } from "@/styles/CommonStyle.js";
+
+const Styled = {
+  CelebInfoContainer: styled.div`
+    padding: 2rem calc((100% - 60rem) / 2);
+  `,
+
+  CelebInfoBottomBox: styled.div`
+    padding-top: 1rem;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 2rem;
+  `,
+
+  ProfileImage: styled.div`
+    width: 10rem;
+    height: 10rem;
+    object-fit: cover;
+    border-radius: 0.25rem;
+    background-color: ${({ theme }) => theme.color.skeleton};
+    overflow: hidden;
+  `,
+
+  TextInfoContainer: styled.div`
+    display: flex;
+    flex-direction: column;
+  `,
+};
+
 function CelebDetailInfoSkeleton() {
-  return <div>셀럽 상세 스켈레톤</div>;
+  return (
+    <Styled.CelebInfoContainer>
+      <CelebProfileSkeleton />
+
+      <Styled.CelebInfoBottomBox>
+        <Styled.ProfileImage>
+          <Shimmer />
+        </Styled.ProfileImage>
+
+        <CelebRankSkeleton />
+
+        <CelebTextInfoSkeleton />
+      </Styled.CelebInfoBottomBox>
+    </Styled.CelebInfoContainer>
+  );
 }
 
 export default CelebDetailInfoSkeleton;

--- a/src/src/components/celebrity-detail/CelebDetailInfoSkeleton.jsx
+++ b/src/src/components/celebrity-detail/CelebDetailInfoSkeleton.jsx
@@ -34,6 +34,10 @@ const Styled = {
   `,
 };
 
+/**
+ * 셀럽 상세정보 스켈레톤 컴포넌트 - 셀럽 상세페이지 상단 전체
+ */
+
 function CelebDetailInfoSkeleton() {
   return (
     <Styled.CelebInfoContainer>

--- a/src/src/components/celebrity-detail/CelebInfoContainerSkeleton.jsx
+++ b/src/src/components/celebrity-detail/CelebInfoContainerSkeleton.jsx
@@ -1,0 +1,5 @@
+function CelebInfoContainerSkeleton() {
+  return <div>CelebInfoContainerSkeleton</div>;
+}
+
+export default CelebInfoContainerSkeleton;

--- a/src/src/components/celebrity-detail/CelebInfoContainerSkeleton.jsx
+++ b/src/src/components/celebrity-detail/CelebInfoContainerSkeleton.jsx
@@ -1,5 +1,0 @@
-function CelebInfoContainerSkeleton() {
-  return <div>CelebInfoContainerSkeleton</div>;
-}
-
-export default CelebInfoContainerSkeleton;

--- a/src/src/components/celebrity-detail/InfiniteCelebRelatedFund.jsx
+++ b/src/src/components/celebrity-detail/InfiniteCelebRelatedFund.jsx
@@ -1,0 +1,54 @@
+import { useRef } from "react";
+import { PropTypes } from "prop-types";
+
+import { CelebRelatedFundDto } from "@/api/dto/celebrity.dto";
+import { GridTemplate } from "@/styles/CommonStyle.js";
+import useInfiniteCelebRelatedFundQuery from "@/hooks/api/celebrity/useInfiniteCelebRealtedFundQuery.js";
+import useIntersectionObserver from "@/hooks/useIntersectionObserver.js";
+
+import FundInfoGridCard from "@/components/fund/FundInfoGridCard.jsx";
+import InfiniteFundInfoLoader from "@/components/fund-list/InfiniteFundInfo.loader.jsx";
+import { useParams } from "react-router-dom";
+
+/**
+ * 셀럽관련 펀딩목록 컴포넌트
+ * @param {number} sortType 순서
+ */
+
+function InfiniteCelebRelatedFund({ sortType }) {
+  const loaderRef = useRef();
+  const { celebId } = useParams();
+
+  const { data: infiniteCelebFundData, fetchNextPage } =
+    useInfiniteCelebRelatedFundQuery({
+      celebId,
+      sortType,
+    });
+
+  useIntersectionObserver(async () => {
+    await fetchNextPage();
+  }, loaderRef);
+
+  const mapInfoToCelebFundDto = (info) => {
+    return new CelebRelatedFundDto({ ...info });
+  };
+
+  return (
+    <>
+      <GridTemplate>
+        {infiniteCelebFundData?.pages.map((page) =>
+          page?.data?.celebRelatedFundList.map((info, index) => (
+            <FundInfoGridCard key={index} {...mapInfoToCelebFundDto(info)} />
+          )),
+        )}
+      </GridTemplate>
+      <InfiniteFundInfoLoader loaderRef={loaderRef} />
+    </>
+  );
+}
+
+InfiniteCelebRelatedFund.propTypes = {
+  sortType: PropTypes.number,
+};
+
+export default InfiniteCelebRelatedFund;

--- a/src/src/components/celebrity-detail/skeleton/CelebProfileSkeleton.jsx
+++ b/src/src/components/celebrity-detail/skeleton/CelebProfileSkeleton.jsx
@@ -1,0 +1,84 @@
+import styled from "styled-components";
+import { Shimmer } from "@/styles/CommonStyle";
+
+const Styled = {
+  ProfileContainer: styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  `,
+
+  Text: styled.div`
+    width: 100%;
+  `,
+
+  NameAndGroup: styled.div`
+    display: flex;
+    .name {
+      width: 5rem;
+      height: 2rem;
+      font-weight: 600;
+      border-radius: 0.25rem;
+      background-color: ${({ theme }) => theme.color.skeleton};
+      overflow: hidden;
+    }
+    .group {
+      width: 3rem;
+      height: 1.4rem;
+      font-weight: 400;
+      margin-top: 0.5rem;
+      margin-left: 0.5rem;
+      border-radius: 0.25rem;
+      background-color: ${({ theme }) => theme.color.skeleton};
+      overflow: hidden;
+    }
+  `,
+
+  CategoryAndGender: styled.div`
+    margin: 0.5rem 0;
+    width: 6rem;
+    height: 1.2rem;
+    border-radius: 0.25rem;
+    background-color: ${({ theme }) => theme.color.skeleton};
+    overflow: hidden;
+  `,
+
+  FollowButton: styled.div`
+    padding: 0.5rem;
+    height: 2.2rem;
+    width: 4.8rem;
+    border-radius: 0.25rem;
+    background-color: ${({ theme }) => theme.color.skeleton};
+    overflow: hidden;
+  `,
+};
+
+/**
+ * 설럽프로필 스켈레톤 컴포넌트 - 셀럽상세페이지 상단 프로필
+ */
+function CelebProfileSkeleton() {
+  return (
+    <Styled.ProfileContainer>
+      <Styled.Text>
+        <Styled.NameAndGroup>
+          <div className="name">
+            <Shimmer />
+          </div>
+          <div className="group">
+            <Shimmer />
+          </div>
+        </Styled.NameAndGroup>
+
+        <Styled.CategoryAndGender>
+          <Shimmer />
+        </Styled.CategoryAndGender>
+      </Styled.Text>
+
+      <Styled.FollowButton>
+        <Shimmer />
+      </Styled.FollowButton>
+    </Styled.ProfileContainer>
+  );
+}
+
+export default CelebProfileSkeleton;

--- a/src/src/components/celebrity-detail/skeleton/CelebRankSkeleton.jsx
+++ b/src/src/components/celebrity-detail/skeleton/CelebRankSkeleton.jsx
@@ -1,0 +1,62 @@
+import { styled } from "styled-components";
+import { Shimmer } from "@/styles/CommonStyle";
+
+const Styled = {
+  RankContainer: styled.div`
+    display: flex;
+  `,
+  Rank: styled.div`
+    margin: 0 1rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    .rank {
+      margin-bottom: 0.5rem;
+      width: 3rem;
+      height: 3rem;
+      font-weight: 500;
+      border-radius: 0.25rem;
+      background-color: ${({ theme }) => theme.color.skeleton};
+      overflow: hidden;
+    }
+
+    .rank-desc {
+      white-space: nowrap;
+      width: 3rem;
+      height: 1rem;
+      border-radius: 0.25rem;
+      background-color: ${({ theme }) => theme.color.skeleton};
+      overflow: hidden;
+    }
+  `,
+};
+
+/**
+ * 셀럽 순위 스켈레톤 컴포넌트 - 셀럽상세페이지 상단 순위아이콘 및 텍스트
+ */
+
+function CelebRankSkeleton() {
+  return (
+    <Styled.RankContainer>
+      <Styled.Rank>
+        <div className="rank">
+          <Shimmer />
+        </div>
+        <div className="rank-desc">
+          <Shimmer />
+        </div>
+      </Styled.Rank>
+      <Styled.Rank>
+        <div className="rank">
+          <Shimmer />
+        </div>
+        <div className="rank-desc">
+          <Shimmer />
+        </div>
+      </Styled.Rank>
+    </Styled.RankContainer>
+  );
+}
+
+export default CelebRankSkeleton;

--- a/src/src/components/celebrity-detail/skeleton/CelebTextInfoSkeleton.jsx
+++ b/src/src/components/celebrity-detail/skeleton/CelebTextInfoSkeleton.jsx
@@ -1,0 +1,74 @@
+import styled from "styled-components";
+import { Shimmer } from "@/styles/CommonStyle";
+
+const Styled = {
+  TextContainer: styled.div``,
+
+  Text: styled.div`
+    display: flex;
+    align-items: center;
+    margin-top: 1rem;
+
+    &:first-child {
+      margin-top: 0;
+    }
+
+    .text {
+      margin-left: 0.4rem;
+      white-space: nowrap;
+      font-weight: 500;
+      width: 7rem;
+      height: 1.3rem;
+      border-radius: 0.25rem;
+      background-color: ${({ theme }) => theme.color.skeleton};
+      overflow: hidden;
+    }
+  `,
+
+  Icon: styled.div`
+    width: 2rem;
+    height: 2rem;
+    border-radius: 0.25rem;
+    background-color: ${({ theme }) => theme.color.skeleton};
+    overflow: hidden;
+  `,
+};
+
+/**
+ * 셀럽 텍스트정보 스켈레톶 컴포넌트 - 셀럽 상세페이지 상단우측 텍스트정보
+ */
+
+function CelebTextInfoSkeleton() {
+  return (
+    <Styled.TextContainer>
+      <Styled.Text>
+        <Styled.Icon>
+          <Shimmer />
+        </Styled.Icon>
+        <div className="text">
+          <Shimmer />
+        </div>
+      </Styled.Text>
+
+      <Styled.Text>
+        <Styled.Icon>
+          <Shimmer />
+        </Styled.Icon>
+        <div className="text">
+          <Shimmer />
+        </div>
+      </Styled.Text>
+
+      <Styled.Text>
+        <Styled.Icon>
+          <Shimmer />
+        </Styled.Icon>
+        <div className="text">
+          <Shimmer />
+        </div>
+      </Styled.Text>
+    </Styled.TextContainer>
+  );
+}
+
+export default CelebTextInfoSkeleton;

--- a/src/src/hooks/api/celebrity/useCelebDetailInfoQuery.js
+++ b/src/src/hooks/api/celebrity/useCelebDetailInfoQuery.js
@@ -1,0 +1,17 @@
+import { useQuery } from "@tanstack/react-query";
+import API from "@/constants.API.js";
+import celebrityAPI from "@/api/celebrityAPI.js";
+
+function useCelebDetailInfoQuery({ celebId }) {
+  return useQuery(
+    [API.CELEBRITY.DTAIL(celebId)],
+    async () => {
+      return await celebrityAPI.getCelebDetailInfo(celebId);
+    },
+    {
+      suspense: true,
+    },
+  );
+}
+
+export default useCelebDetailInfoQuery;

--- a/src/src/hooks/api/celebrity/useCelebDetailInfoQuery.js
+++ b/src/src/hooks/api/celebrity/useCelebDetailInfoQuery.js
@@ -4,10 +4,15 @@ import celebrityAPI from "@/api/celebrityAPI.js";
 
 function useCelebDetailInfoQuery({ celebId }) {
   console.log("커스텀으로 넘어온 셀럽아이디", celebId);
-  return useQuery([API.CELEBRITY.DETAIL(celebId)], async () => {
-    console.log(`이제 셀럽아이디 ${celebId}로 호출할거임`);
-    return await celebrityAPI.getCelebDetailInfo(celebId);
-  });
+  return useQuery(
+    [API.CELEBRITY.DETAIL(celebId), celebId],
+    async () => {
+      return await celebrityAPI.getCelebDetailInfo(celebId);
+    },
+    {
+      suspense: true,
+    },
+  );
 }
 
 export default useCelebDetailInfoQuery;

--- a/src/src/hooks/api/celebrity/useCelebDetailInfoQuery.js
+++ b/src/src/hooks/api/celebrity/useCelebDetailInfoQuery.js
@@ -5,7 +5,7 @@ import celebrityAPI from "@/api/celebrityAPI.js";
 function useCelebDetailInfoQuery({ celebId }) {
   console.log("커스텀으로 넘어온 셀럽아이디", celebId);
   return useQuery(
-    [API.CELEBRITY.DETAIL(celebId), celebId],
+    [API.CELEBRITY.DETAIL(celebId)],
     async () => {
       return await celebrityAPI.getCelebDetailInfo(celebId);
     },

--- a/src/src/hooks/api/celebrity/useCelebDetailInfoQuery.js
+++ b/src/src/hooks/api/celebrity/useCelebDetailInfoQuery.js
@@ -1,17 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
-import API from "@/constants.API.js";
+import API from "@/constants/API.js";
 import celebrityAPI from "@/api/celebrityAPI.js";
 
 function useCelebDetailInfoQuery({ celebId }) {
-  return useQuery(
-    [API.CELEBRITY.DTAIL(celebId)],
-    async () => {
-      return await celebrityAPI.getCelebDetailInfo(celebId);
-    },
-    {
-      suspense: true,
-    },
-  );
+  console.log("커스텀으로 넘어온 셀럽아이디", celebId);
+  return useQuery([API.CELEBRITY.DETAIL(celebId)], async () => {
+    console.log(`이제 셀럽아이디 ${celebId}로 호출할거임`);
+    return await celebrityAPI.getCelebDetailInfo(celebId);
+  });
 }
 
 export default useCelebDetailInfoQuery;

--- a/src/src/hooks/api/celebrity/useCelebDetailInfoQuery.js
+++ b/src/src/hooks/api/celebrity/useCelebDetailInfoQuery.js
@@ -3,7 +3,6 @@ import API from "@/constants/API.js";
 import celebrityAPI from "@/api/celebrityAPI.js";
 
 function useCelebDetailInfoQuery({ celebId }) {
-  console.log("커스텀으로 넘어온 셀럽아이디", celebId);
   return useQuery(
     [API.CELEBRITY.DETAIL(celebId)],
     async () => {

--- a/src/src/hooks/api/celebrity/useInfiniteCelebRealtedFundQuery.js
+++ b/src/src/hooks/api/celebrity/useInfiniteCelebRealtedFundQuery.js
@@ -2,14 +2,13 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 import API from "@/constants/API.js";
 import celebrityAPI from "@/api/celebrityAPI.js";
 
-function useInfiniteCelebRelatedFundQuery({ celebId, keyword, sortType }) {
+function useInfiniteCelebRelatedFundQuery({ celebId, sortType }) {
   return useInfiniteQuery(
-    [API.CELEBRITY.FUNDING, celebId, keyword, sortType],
+    [API.CELEBRITY.FUNDING(celebId), sortType],
     async ({ pageParam = 0 }) => {
       return celebrityAPI.getCelebRelatedFund({
         celebId: celebId,
         pageIndex: pageParam,
-        keyword: keyword,
         sortType: sortType,
       });
     },

--- a/src/src/hooks/api/celebrity/useInfiniteCelebRealtedFundQuery.js
+++ b/src/src/hooks/api/celebrity/useInfiniteCelebRealtedFundQuery.js
@@ -1,0 +1,25 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import API from "@/constants/API.js";
+import celebrityAPI from "@/api/celebrityAPI.js";
+
+function useInfiniteCelebRelatedFundQuery({ celebId, keyword, sortType }) {
+  return useInfiniteQuery(
+    [API.CELEBRITY.FUNDING, celebId, keyword, sortType],
+    async ({ pageParam = 0 }) => {
+      return celebrityAPI.getCelebRelatedFund({
+        celebId: celebId,
+        pageIndex: pageParam,
+        keyword: keyword,
+        sortType: sortType,
+      });
+    },
+    {
+      suspense: true,
+      getNextPageParam: (lastPage) => {
+        return lastPage.config.params.pageIndex + 1;
+      },
+    },
+  );
+}
+
+export default useInfiniteCelebRelatedFundQuery;

--- a/src/src/mocks/handler/celebrityHandlers.js
+++ b/src/src/mocks/handler/celebrityHandlers.js
@@ -1,6 +1,7 @@
 import { rest } from "msw";
 import API from "@/constants/API.js";
 
+// 셀럽 목록조회 데이터
 const sonnyCelebInfo = {
   celebId: 1,
   celebName: "손흥민",
@@ -46,6 +47,78 @@ const youngCelebInfo = {
   followerNum: 10000,
   isFollowing: false,
   rank: 4,
+};
+
+// 셀럽상세정보 데이터
+const sonnyCelebDetailInfo = {
+  celebId: 1,
+  celebName: "손흥민",
+  celebGroup: "토트넘",
+  celebGender: "남",
+  celebCategory: "스포츠",
+  profileUrl:
+    "https://pds.joongang.co.kr/news/component/htmlphoto_mmdata/202308/13/3756de8c-1ea6-4988-b063-25f26d9b76d5.jpg",
+  fundInProgressNum: 30,
+  totalFundMoney: 35000000,
+  followerNum: 10000,
+  isFollowing: false,
+  rank: {
+    follower: 1,
+    fundMoney: 2,
+  },
+};
+
+const kinginCelebDetailInfo = {
+  celebId: 2,
+  celebName: "이강인",
+  celebGroup: "PSG",
+  celebGender: "남",
+  celebCategory: "스포츠",
+  profileUrl:
+    "https://pds.joongang.co.kr/news/component/htmlphoto_mmdata/202308/13/3756de8c-1ea6-4988-b063-25f26d9b76d5.jpg",
+  fundInProgressNum: 32,
+  totalFundMoney: 38000000,
+  followerNum: 9000,
+  isFollowing: false,
+  rank: {
+    follower: 2,
+    fundMoney: 1,
+  },
+};
+
+const wooCelebDetailInfo = {
+  celebId: 3,
+  celebName: "설영우",
+  celebGender: "남",
+  celebCategory: "스포츠",
+  profileUrl:
+    "https://pds.joongang.co.kr/news/component/htmlphoto_mmdata/202308/13/3756de8c-1ea6-4988-b063-25f26d9b76d5.jpg",
+  fundInProgressNum: 26,
+  totalFundMoney: 35000000,
+  followerNum: 8000,
+  isFollowing: false,
+  rank: {
+    follower: 3,
+    fundMoney: 3,
+  },
+};
+
+const youngCelebDetailInfo = {
+  celebId: 4,
+  celebName: "이재용",
+  celebGroup: "삼성",
+  celebGender: "남",
+  celebCategory: "기타",
+  profileUrl:
+    "https://pds.joongang.co.kr/news/component/htmlphoto_mmdata/202308/13/3756de8c-1ea6-4988-b063-25f26d9b76d5.jpg",
+  fundInProgressNum: 25,
+  totalFundMoney: 7500,
+  followerNum: 10000,
+  isFollowing: false,
+  rank: {
+    follower: 4,
+    fundMoney: 4,
+  },
 };
 
 export const celebrityHandlers = [
@@ -129,5 +202,28 @@ export const celebrityHandlers = [
       ctx.status(200),
       ctx.json({ message: "성공적으로 셀럽신청이 완료되었습니다." }),
     );
+  }),
+
+  // 셀럽 상세정보 조회
+  rest.get("/api" + API.CELEBRITY.DETAIL(":celebId"), (req, res, ctx) => {
+    const { celebId } = req.params;
+
+    const celebDetailData = {
+      1: sonnyCelebDetailInfo,
+      2: kinginCelebDetailInfo,
+      3: wooCelebDetailInfo,
+      4: youngCelebDetailInfo,
+    };
+
+    const celebDetailInfo = celebDetailData[celebId];
+
+    if (celebDetailInfo) {
+      return res(ctx.status(200), ctx.json(celebDetailInfo));
+    } else {
+      return res(
+        ctx.status(400),
+        ctx.json({ message: "존재하지 않는 셀럽입니다" }),
+      );
+    }
   }),
 ];

--- a/src/src/mocks/handler/celebrityHandlers.js
+++ b/src/src/mocks/handler/celebrityHandlers.js
@@ -75,7 +75,7 @@ const kinginCelebDetailInfo = {
   celebGender: "남",
   celebCategory: "스포츠",
   profileUrl:
-    "https://pds.joongang.co.kr/news/component/htmlphoto_mmdata/202308/13/3756de8c-1ea6-4988-b063-25f26d9b76d5.jpg",
+    "https://i.namu.wiki/i/sfvk_xnvWlwCiFo3X6cdfzf621AlwLjGRZ88bIcrIt99EwxqOQVGGp7gMEH6gllADZl1kLJdIeJD3Ooq4LOYOg.webp",
   fundInProgressNum: 32,
   totalFundMoney: 38000000,
   followerNum: 9000,
@@ -92,7 +92,7 @@ const wooCelebDetailInfo = {
   celebGender: "남",
   celebCategory: "스포츠",
   profileUrl:
-    "https://pds.joongang.co.kr/news/component/htmlphoto_mmdata/202308/13/3756de8c-1ea6-4988-b063-25f26d9b76d5.jpg",
+    "https://i.namu.wiki/i/mFwo5sbcGmtVmDcBxMi36FF5-nPXUs5mfoN2pB3YsbAmJe6h4wX35IT2jQZxNOdqE2BtMgbji8Yp-jvCLs4nsQ.webp",
   fundInProgressNum: 26,
   totalFundMoney: 35000000,
   followerNum: 8000,
@@ -109,8 +109,7 @@ const youngCelebDetailInfo = {
   celebGroup: "삼성",
   celebGender: "남",
   celebCategory: "기타",
-  profileUrl:
-    "https://pds.joongang.co.kr/news/component/htmlphoto_mmdata/202308/13/3756de8c-1ea6-4988-b063-25f26d9b76d5.jpg",
+  profileUrl: "https://cdn.thelec.kr/news/photo/202210/18518_16299_646.jpg",
   fundInProgressNum: 25,
   totalFundMoney: 7500,
   followerNum: 10000,

--- a/src/src/mocks/handler/celebrityHandlers.js
+++ b/src/src/mocks/handler/celebrityHandlers.js
@@ -159,6 +159,80 @@ const sonnyFundInfo2 = {
   isInUserWishList: false,
 };
 
+const kinginFundInfo1 = {
+  celebId: 2,
+  fundId: 1,
+  fundTitle:
+    "이강인 해외리그 기념 지하철 광고 🎉🎉 축구중독자가 책임지고 펀딩합니다 ❤️‍🔥",
+  thumbnailUrl:
+    "https://cdn.footballist.co.kr/news/photo/202307/169736_99635_1839.jpg",
+  targetDate: "2023-12-17",
+  targetMoney: "3000000",
+  currentMoney: "2340000",
+  celebrityId: "kingin",
+  celebrityName: "이강인",
+  celebrityProfileUrl:
+    "https://i.namu.wiki/i/sfvk_xnvWlwCiFo3X6cdfzf621AlwLjGRZ88bIcrIt99EwxqOQVGGp7gMEH6gllADZl1kLJdIeJD3Ooq4LOYOg.webp",
+  organizerId: "soccer456",
+  organizerName: "축구냠냠",
+  isInUserWishList: true,
+};
+
+const kinginFundInfo2 = {
+  celebId: 2,
+  fundId: 2,
+  fundTitle: "킹인 폼 미쳤다 토트넘역 지하철 광고판 달자",
+  thumbnailUrl:
+    "https://newsimg-hams.hankookilbo.com/2022/09/21/79cc00a1-76da-49b4-9177-0e1b83cb94a2.jpg",
+  targetDate: "2023-12-24",
+  targetMoney: "5000000",
+  currentMoney: "100000",
+  celebrityId: "kingin",
+  celebrityName: "이강인",
+  celebrityProfileUrl:
+    "https://pds.joongang.co.kr/news/component/htmlphoto_mmdata/202308/13/3756de8c-1ea6-4988-b063-25f26d9b76d5.jpg",
+  isFollowing: false,
+  organizerId: "soccer444",
+  organizerName: "축덕추덕",
+  isInUserWishList: false,
+};
+const wooFundInfo1 = {
+  celebId: 3,
+  fundId: 1,
+  fundTitle: "영우존잘 얼굴찬양할래 ❤️‍🔥",
+  thumbnailUrl:
+    "https://image.fnnews.com/resource/media/image/2021/12/06/202112061111508101_l.jpg",
+  targetDate: "2023-12-17",
+  targetMoney: "3000000",
+  currentMoney: "2340000",
+  celebrityId: "youngwoo",
+  celebrityName: "설영우",
+  celebrityProfileUrl:
+    "https://i.namu.wiki/i/sfvk_xnvWlwCiFo3X6cdfzf621AlwLjGRZ88bIcrIt99EwxqOQVGGp7gMEH6gllADZl1kLJdIeJD3Ooq4LOYOg.webp",
+  organizerId: "soccer456",
+  organizerName: "미남선수",
+  isInUserWishList: true,
+};
+
+const wooFundInfo2 = {
+  celebId: 3,
+  fundId: 2,
+  fundTitle: " 폼 미쳤다 울산역 지하철 광고판 달자",
+  thumbnailUrl:
+    "https://newsimg-hams.hankookilbo.com/2023/04/13/e3d837cb-8ff7-4de6-9188-c4c8a5391b33.jpg",
+  targetDate: "2023-12-24",
+  targetMoney: "5000000",
+  currentMoney: "100000",
+  celebrityId: "kingin",
+  celebrityName: "설영우",
+  celebrityProfileUrl:
+    "https://pds.joongang.co.kr/news/component/htmlphoto_mmdata/202308/13/3756de8c-1ea6-4988-b063-25f26d9b76d5.jpg",
+  isFollowing: false,
+  organizerId: "soccer444",
+  organizerName: "우아아아",
+  isInUserWishList: false,
+};
+
 export const celebrityHandlers = [
   // 셀럽 목록 조회
   rest.get("/api" + API.CELEBRITY.LIST, (req, res, ctx) => {
@@ -274,11 +348,21 @@ export const celebrityHandlers = [
     if (!pageIndex) return res(ctx.status(400, "pageIndex 없음"));
     if (!celebId) return res(ctx.status(400, "celebId 없음"));
 
+    const filteredFunds = [
+      sonnyFundInfo1,
+      sonnyFundInfo2,
+      kinginFundInfo1,
+      kinginFundInfo2,
+      wooFundInfo1,
+      wooFundInfo2,
+    ].filter((fundInfo) => fundInfo.celebId === parseInt(celebId));
+
     return res(
       ctx.status(200),
       ctx.json({
-        celebRelatedFundList: Array.from({ length: 12 }, (_, i) =>
-          i % 2 ? sonnyFundInfo2 : sonnyFundInfo1,
+        celebRelatedFundList: Array.from(
+          { length: 12 },
+          (_, i) => filteredFunds[i % filteredFunds.length],
         ),
         isLastPage: false,
         currentPage: pageIndex,

--- a/src/src/mocks/handler/celebrityHandlers.js
+++ b/src/src/mocks/handler/celebrityHandlers.js
@@ -120,6 +120,45 @@ const youngCelebDetailInfo = {
   },
 };
 
+//셀럽관련 펀딩목록 조회 데이터
+const sonnyFundInfo1 = {
+  celebId: 1,
+  fundId: 1,
+  fundTitle:
+    "손흥민 주장된 기념 지하철 광고 🎉🎉 축구중독자가 책임지고 펀딩합니다 ❤️‍🔥",
+  thumbnailUrl:
+    "https://ichef.bbci.co.uk/news/640/cpsprodpb/4118/production/_119546661_gettyimages-1294130887.jpg",
+  targetDate: "2023-12-17",
+  targetMoney: "3000000",
+  currentMoney: "2340000",
+  celebrityId: "sonny",
+  celebrityName: "손흥민",
+  celebrityProfileUrl:
+    "https://pds.joongang.co.kr/news/component/htmlphoto_mmdata/202308/13/3756de8c-1ea6-4988-b063-25f26d9b76d5.jpg",
+  organizerId: "soccer123",
+  organizerName: "축구도사",
+  isInUserWishList: true,
+};
+
+const sonnyFundInfo2 = {
+  celebId: 1,
+  fundId: 2,
+  fundTitle: "쏘니 폼 미쳤다 토트넘역 지하철 광고판 달자",
+  thumbnailUrl:
+    "https://assets.goal.com/v3/assets/bltcc7a7ffd2fbf71f5/bltaf10a2ea551a3e54/6360dc8f67675010b765f257/GettyImages-1432946487.jpg",
+  targetDate: "2023-12-24",
+  targetMoney: "5000000",
+  currentMoney: "100000",
+  celebrityId: "sonny",
+  celebrityName: "손흥민",
+  celebrityProfileUrl:
+    "https://pds.joongang.co.kr/news/component/htmlphoto_mmdata/202308/13/3756de8c-1ea6-4988-b063-25f26d9b76d5.jpg",
+  isFollowing: false,
+  organizerId: "soccer234",
+  organizerName: "싸커이삼사",
+  isInUserWishList: false,
+};
+
 export const celebrityHandlers = [
   // 셀럽 목록 조회
   rest.get("/api" + API.CELEBRITY.LIST, (req, res, ctx) => {
@@ -224,5 +263,29 @@ export const celebrityHandlers = [
         ctx.json({ message: "존재하지 않는 셀럽입니다" }),
       );
     }
+  }),
+
+  // 셀럽관련 펀딩목록 조회
+  rest.get("/api" + API.CELEBRITY.FUNDING(":celebId"), (req, res, ctx) => {
+    const keyword = req.url.searchParams.get("keyword");
+    const pageIndex = req.url.searchParams.get("pageIndex");
+    const sortType = req.url.searchParams.get("sortType");
+    const { celebId } = req.params;
+
+    if (!pageIndex) return res(ctx.status(400, "pageIndex 없음"));
+    if (!celebId) return res(ctx.status(400, "celebId 없음"));
+
+    return res(
+      ctx.status(200),
+      ctx.json({
+        celebRelatedFundList: Array.from({ length: 12 }, (_, i) =>
+          i % 2 ? sonnyFundInfo2 : sonnyFundInfo1,
+        ),
+        isLastPage: false,
+        currentPage: pageIndex,
+        keyword: keyword,
+        sortType: sortType,
+      }),
+    );
   }),
 ];

--- a/src/src/mocks/handler/celebrityHandlers.js
+++ b/src/src/mocks/handler/celebrityHandlers.js
@@ -267,7 +267,6 @@ export const celebrityHandlers = [
 
   // 셀럽관련 펀딩목록 조회
   rest.get("/api" + API.CELEBRITY.FUNDING(":celebId"), (req, res, ctx) => {
-    const keyword = req.url.searchParams.get("keyword");
     const pageIndex = req.url.searchParams.get("pageIndex");
     const sortType = req.url.searchParams.get("sortType");
     const { celebId } = req.params;
@@ -283,7 +282,6 @@ export const celebrityHandlers = [
         ),
         isLastPage: false,
         currentPage: pageIndex,
-        keyword: keyword,
         sortType: sortType,
       }),
     );

--- a/src/src/pages/CelebrityDetail.page.jsx
+++ b/src/src/pages/CelebrityDetail.page.jsx
@@ -1,48 +1,14 @@
 import { Suspense, useState } from "react";
-import { useParams } from "react-router-dom";
-import styled from "styled-components";
 
-import CelebTextInfo from "@/components/celebrity-detail/CelebTextInfo.jsx";
-import CelebProfile from "@/components/celebrity-detail/CelebProfile.jsx";
-import CelebRank from "@/components/celebrity-detail/CelebRank.jsx";
+import { GridTemplate } from "@/styles/CommonStyle.js";
+
+import CelebDetailInfoSkeleton from "@/components/celebrity-detail/CelebDetailInfoSkeleton.jsx";
+import CelebDetailInfo from "@/components/celebrity-detail/CelebDetailInfo";
 import Tabs from "@/components/common/button/TabButtons.jsx";
 import FundInfoGridCard from "@/components/fund/FundInfoGridCard.jsx";
 
-import { GridTemplate } from "@/styles/CommonStyle.js";
-import useCelebDetailInfoQuery from "@/hooks/api/celebrity/useCelebDetailInfoQuery.js";
-import CelebInfoContainerSkeleton from "@/components/celebrity-detail/CelebInfoContainerSkeleton.jsx";
-
-const Styled = {
-  CelebInfoContainer: styled.div`
-    padding: 2rem calc((100% - 60rem) / 2);
-  `,
-
-  CelebInfoBottomBox: styled.div`
-    padding-top: 1rem;
-    display: flex;
-    justify-content: space-evenly;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 2rem;
-  `,
-
-  ProfileImage: styled.img`
-    width: 10rem;
-    height: 10rem;
-    object-fit: cover;
-    border-radius: 0.25rem;
-  `,
-
-  TextInfoContainer: styled.div`
-    display: flex;
-    flex-direction: column;
-  `,
-};
-
 function CelebrityDetailPage() {
   const [selectedTab, setSelectedTab] = useState(0);
-  const { celebId } = useParams();
-  const { data } = useCelebDetailInfoQuery({ celebId: celebId });
 
   const fundInfo = {
     fundId: 1,
@@ -74,36 +40,8 @@ function CelebrityDetailPage() {
 
   return (
     <>
-      <Suspense fallback={<CelebInfoContainerSkeleton />}>
-        <Styled.CelebInfoContainer>
-          <CelebProfile
-            celebName={data?.celebName}
-            celebGroup={data?.celebGroup}
-            celebCategory={data?.celebCategory}
-            celebGender={data?.celebGender}
-            celebId={data?.celebId}
-            isFollowing={data?.isFollowing}
-          />
-
-          <Styled.CelebInfoBottomBox>
-            <Styled.ProfileImage
-              src={data?.profileUrl}
-              alt={`${data?.celebName}의 프로필 사진`}
-            />
-
-            <CelebRank
-              followerRank={data?.rank.follower}
-              fundingRank={data?.rank.fundMoney}
-            />
-
-            <CelebTextInfo
-              fundInProgressNum={data?.fundInProgressNum}
-              followerNum={data?.followerNum}
-              isFollowing={data?.isFollowing}
-              totalFundMoney={data?.totalFundMoney}
-            />
-          </Styled.CelebInfoBottomBox>
-        </Styled.CelebInfoContainer>
+      <Suspense fallback={<CelebDetailInfoSkeleton />}>
+        <CelebDetailInfo />
       </Suspense>
 
       <Tabs tabInfoArray={tabInfoArray} style={{ paddingBottom: "1rem" }} />

--- a/src/src/pages/CelebrityDetail.page.jsx
+++ b/src/src/pages/CelebrityDetail.page.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useParams } from "react-router-dom";
 import styled from "styled-components";
 
 import CelebTextInfo from "@/components/celebrity-detail/CelebTextInfo.jsx";
@@ -6,7 +7,9 @@ import CelebProfile from "@/components/celebrity-detail/CelebProfile.jsx";
 import CelebRank from "@/components/celebrity-detail/CelebRank.jsx";
 import Tabs from "@/components/common/button/TabButtons.jsx";
 import FundInfoGridCard from "@/components/fund/FundInfoGridCard.jsx";
+
 import { GridTemplate } from "@/styles/CommonStyle.js";
+import useCelebDetailInfoQuery from "@/hooks/api/celebrity/useCelebDetailInfoQuery";
 
 const Styled = {
   CelebInfoContainer: styled.div`
@@ -37,24 +40,10 @@ const Styled = {
 
 function CelebrityDetailPage() {
   const [selectedTab, setSelectedTab] = useState(0);
-
-  const celebInfo = {
-    celebId: 1,
-    celebName: "손흥민",
-    celebGroup: "토트넘",
-    celebGender: "남",
-    celebCategory: "스포츠",
-    profileUrl:
-      "https://pds.joongang.co.kr/news/component/htmlphoto_mmdata/202308/13/3756de8c-1ea6-4988-b063-25f26d9b76d5.jpg",
-    fundInProgressNum: 30,
-    totalFundMoney: 35000000,
-    followerNum: 10000,
-    isFollowing: false,
-    rank: {
-      follower: 1,
-      fundMoney: 4,
-    },
-  };
+  const { celebId } = useParams();
+  console.log("셀럽아이디", celebId);
+  const { data } = useCelebDetailInfoQuery({ celebId: celebId });
+  console.log(data);
 
   const fundInfo = {
     fundId: 1,
@@ -88,30 +77,30 @@ function CelebrityDetailPage() {
     <>
       <Styled.CelebInfoContainer>
         <CelebProfile
-          celebName={celebInfo.celebName}
-          celebGroup={celebInfo.celebGroup}
-          celebCategory={celebInfo.celebCategory}
-          celebGender={celebInfo.celebGender}
-          celebId={celebInfo?.celebId}
-          isFollowing={celebInfo?.isFollowing}
+          celebName={data?.celebName}
+          celebGroup={data?.celebGroup}
+          celebCategory={data?.celebCategory}
+          celebGender={data?.celebGender}
+          celebId={data?.celebId}
+          isFollowing={data?.isFollowing}
         />
 
         <Styled.CelebInfoBottomBox>
           <Styled.ProfileImage
-            src={celebInfo?.profileUrl}
-            alt={`${celebInfo?.celebName}의 프로필 사진`}
+            src={data?.profileUrl}
+            alt={`${data?.celebName}의 프로필 사진`}
           />
 
           <CelebRank
-            followerRank={celebInfo.rank.follower}
-            fundingRank={celebInfo.rank.fundMoney}
+            followerRank={data?.rank.follower}
+            fundingRank={data?.rank.fundMoney}
           />
 
           <CelebTextInfo
-            fundInProgressNum={celebInfo.fundInProgressNum}
-            followerNum={celebInfo.followerNum}
-            isFollowing={celebInfo.isFollowing}
-            totalFundMoney={celebInfo.totalFundMoney}
+            fundInProgressNum={data?.fundInProgressNum}
+            followerNum={data?.followerNum}
+            isFollowing={data?.isFollowing}
+            totalFundMoney={data?.totalFundMoney}
           />
         </Styled.CelebInfoBottomBox>
       </Styled.CelebInfoContainer>

--- a/src/src/pages/CelebrityDetail.page.jsx
+++ b/src/src/pages/CelebrityDetail.page.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import { useParams } from "react-router-dom";
 import styled from "styled-components";
 
@@ -9,7 +9,8 @@ import Tabs from "@/components/common/button/TabButtons.jsx";
 import FundInfoGridCard from "@/components/fund/FundInfoGridCard.jsx";
 
 import { GridTemplate } from "@/styles/CommonStyle.js";
-import useCelebDetailInfoQuery from "@/hooks/api/celebrity/useCelebDetailInfoQuery";
+import useCelebDetailInfoQuery from "@/hooks/api/celebrity/useCelebDetailInfoQuery.js";
+import CelebInfoContainerSkeleton from "@/components/celebrity-detail/CelebInfoContainerSkeleton.jsx";
 
 const Styled = {
   CelebInfoContainer: styled.div`
@@ -41,9 +42,7 @@ const Styled = {
 function CelebrityDetailPage() {
   const [selectedTab, setSelectedTab] = useState(0);
   const { celebId } = useParams();
-  console.log("셀럽아이디", celebId);
   const { data } = useCelebDetailInfoQuery({ celebId: celebId });
-  console.log(data);
 
   const fundInfo = {
     fundId: 1,
@@ -75,35 +74,37 @@ function CelebrityDetailPage() {
 
   return (
     <>
-      <Styled.CelebInfoContainer>
-        <CelebProfile
-          celebName={data?.celebName}
-          celebGroup={data?.celebGroup}
-          celebCategory={data?.celebCategory}
-          celebGender={data?.celebGender}
-          celebId={data?.celebId}
-          isFollowing={data?.isFollowing}
-        />
-
-        <Styled.CelebInfoBottomBox>
-          <Styled.ProfileImage
-            src={data?.profileUrl}
-            alt={`${data?.celebName}의 프로필 사진`}
-          />
-
-          <CelebRank
-            followerRank={data?.rank.follower}
-            fundingRank={data?.rank.fundMoney}
-          />
-
-          <CelebTextInfo
-            fundInProgressNum={data?.fundInProgressNum}
-            followerNum={data?.followerNum}
+      <Suspense fallback={<CelebInfoContainerSkeleton />}>
+        <Styled.CelebInfoContainer>
+          <CelebProfile
+            celebName={data?.celebName}
+            celebGroup={data?.celebGroup}
+            celebCategory={data?.celebCategory}
+            celebGender={data?.celebGender}
+            celebId={data?.celebId}
             isFollowing={data?.isFollowing}
-            totalFundMoney={data?.totalFundMoney}
           />
-        </Styled.CelebInfoBottomBox>
-      </Styled.CelebInfoContainer>
+
+          <Styled.CelebInfoBottomBox>
+            <Styled.ProfileImage
+              src={data?.profileUrl}
+              alt={`${data?.celebName}의 프로필 사진`}
+            />
+
+            <CelebRank
+              followerRank={data?.rank.follower}
+              fundingRank={data?.rank.fundMoney}
+            />
+
+            <CelebTextInfo
+              fundInProgressNum={data?.fundInProgressNum}
+              followerNum={data?.followerNum}
+              isFollowing={data?.isFollowing}
+              totalFundMoney={data?.totalFundMoney}
+            />
+          </Styled.CelebInfoBottomBox>
+        </Styled.CelebInfoContainer>
+      </Suspense>
 
       <Tabs tabInfoArray={tabInfoArray} style={{ paddingBottom: "1rem" }} />
       <GridTemplate>

--- a/src/src/pages/CelebrityDetail.page.jsx
+++ b/src/src/pages/CelebrityDetail.page.jsx
@@ -1,40 +1,22 @@
 import { Suspense, useState } from "react";
 
-import { GridTemplate } from "@/styles/CommonStyle.js";
-
 import CelebDetailInfoSkeleton from "@/components/celebrity-detail/CelebDetailInfoSkeleton.jsx";
 import CelebDetailInfo from "@/components/celebrity-detail/CelebDetailInfo";
 import Tabs from "@/components/common/button/TabButtons.jsx";
-import FundInfoGridCard from "@/components/fund/FundInfoGridCard.jsx";
+import InfiniteCelebRelatedFund from "@/components/celebrity-detail/InfiniteCelebRelatedFund.jsx";
+import InfiniteFundInfoLoader from "@/components/fund-list/InfiniteFundInfo.loader.jsx";
 
 function CelebrityDetailPage() {
-  const [selectedTab, setSelectedTab] = useState(0);
-
-  const fundInfo = {
-    fundId: 1,
-    fundTitle:
-      "손흥민 주장된 기념 지하철 광고 🎉🎉 축구중독자가 책임지고 펀딩합니다 ❤️‍🔥",
-    thumbnailUrl:
-      "https://ichef.bbci.co.uk/news/640/cpsprodpb/4118/production/_119546661_gettyimages-1294130887.jpg",
-    targetDate: "2023-12-17",
-    targetMoney: "3000000",
-    currentMoney: "2340000",
-    celebrityId: "sonny",
-    celebrityName: "손흥민",
-    celebrityProfileUrl:
-      "https://pds.joongang.co.kr/news/component/htmlphoto_mmdata/202308/13/3756de8c-1ea6-4988-b063-25f26d9b76d5.jpg",
-    organizerId: "soccer123",
-    organizerName: "축구도사",
-  };
+  const [sortType, setSortType] = useState(0);
 
   const tabInfoArray = [
     {
       title: "진행중 펀딩",
-      func: () => setSelectedTab(0),
+      func: () => setSortType(0),
     },
     {
       title: "마감된 펀딩",
-      func: () => setSelectedTab(1),
+      func: () => setSortType(1),
     },
   ];
 
@@ -45,24 +27,10 @@ function CelebrityDetailPage() {
       </Suspense>
 
       <Tabs tabInfoArray={tabInfoArray} style={{ paddingBottom: "1rem" }} />
-      <GridTemplate>
-        {new Array(6).fill(fundInfo).map((info, index) => (
-          <FundInfoGridCard
-            key={index}
-            fundId={fundInfo.fundId}
-            fundTitle={fundInfo.fundTitle}
-            thumbnailUrl={fundInfo.thumbnailUrl}
-            targetDate={fundInfo.targetDate}
-            targetMoney={fundInfo.targetMoney}
-            currentMoney={fundInfo.currentMoney}
-            celebrityId={fundInfo.celebrityId}
-            celebrityProfileUrl={fundInfo.celebrityProfileUrl}
-            celebrityName={fundInfo.celebrityName}
-            organizerId={fundInfo.organizerId}
-            organizerName={fundInfo.organizerName}
-          />
-        ))}
-      </GridTemplate>
+
+      <Suspense fallback={<InfiniteFundInfoLoader />}>
+        <InfiniteCelebRelatedFund sortType={sortType} />
+      </Suspense>
     </>
   );
 }

--- a/src/src/router.jsx
+++ b/src/src/router.jsx
@@ -76,7 +76,7 @@ const router = createBrowserRouter([
       },
       {
         // 셀럽 상세
-        path: `${routes.celebrity}/:celebrityId`,
+        path: `${routes.celebrity}/:celebId`,
         element: <CelebrityDetailPage />,
         errorElement: <div>존재하지 않는 셀럽입니다</div>,
       },


### PR DESCRIPTION
## 주요 사항
 CelebDetailPage의
- 셀럽상세정보(상단) 
- 셀럽관련펀딩목록(하단) / 무한스크롤 celebId로 필터후 fundId 번갈아 펀딩카드 들어가도록
mock api 작업완료하였습니다.

추가 push 예정
- CelebDetailInfoSkeleton 스켈레톤완성
- 누락된 jsdoc들 추가

## 스크린샷
[ 셀럽상세정보]
<img width="1470" alt="스크린샷 2023-11-06 오후 10 15 09" src="https://github.com/Step3-kakao-tech-campus/Team13_FE/assets/124874266/db484eb8-86a2-484d-b546-a0460d24c59b">

[셀럽관련펀딩]
<img width="1468" alt="스크린샷 2023-11-06 오후 10 15 34" src="https://github.com/Step3-kakao-tech-campus/Team13_FE/assets/124874266/ad93d5d3-b1eb-411c-b63f-483a04c0cd23">

## 궁금한 점
셀럽아이디로 관련펀딩을 불러오는게 이렇게 하는게 맞는지 잘 모르겠습니다!


### 관련 이슈
close #114 
